### PR TITLE
Add CasinoSample with simulations to determine poker hand strengths

### DIFF
--- a/ConsoleSamples/Casino_Sample/Card.cs
+++ b/ConsoleSamples/Casino_Sample/Card.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ConsoleSamples.Casino_Sample
+{
+	public class Card : IComparable
+	{
+		public string Suit { get; private set; }
+		public string Rank { get; private set; }
+		public int RankValue
+		{
+			get
+			{
+				return GetRankValue();
+			}
+		}
+		public override string ToString()
+		{
+			return Rank + Suit;
+		}
+
+		// IComparable
+		public int CompareTo(object obj)
+		{
+			if (obj is Card)
+			{
+				if (GetRankValue() < (obj as Card).GetRankValue())
+					return -1;
+				else if (GetRankValue() > (obj as Card).GetRankValue())
+					return 1;
+				else
+					return 0;
+			}
+			throw new ArgumentException("Can't compare a Card to a non-Card.");
+		}
+
+		public Card() : this("A", "s") { }
+
+		public Card(string rank, string suit)
+		{
+			switch (suit.ToLower())
+			{
+				case "s":
+				case "h":
+				case "d":
+				case "c":
+					break;
+				default:
+					throw new ArgumentException();
+			}
+
+			switch (rank.ToLower())
+			{
+				case "a":
+				case "k":
+				case "q":
+				case "j":
+				case "t":
+				case "9":
+				case "8":
+				case "7":
+				case "6":
+				case "5":
+				case "4":
+				case "3":
+				case "2":
+					break;
+				default:
+					throw new ArgumentOutOfRangeException();
+			}
+
+			Suit = suit.ToLower();
+			Rank = rank.ToUpper();
+		}
+
+		int GetRankValue()
+		{
+			switch (Rank)
+			{
+				case "A":
+					return 14; // 0xE
+				case "K":
+					return 13; // 0xD
+				case "Q":
+					return 12; // 0xC
+				case "J":
+					return 11; // 0xB
+				case "T":
+					return 10; // 0xA
+				case "9":
+					return 9;
+				case "8":
+					return 8;
+				case "7":
+					return 7;
+				case "6":
+					return 6;
+				case "5":
+					return 5;
+				case "4":
+					return 4;
+				case "3":
+					return 3;
+				case "2":
+					return 2;
+				default:
+					throw new ArgumentOutOfRangeException();
+			}
+		}
+	}
+}

--- a/ConsoleSamples/Casino_Sample/CasinoSample.cs
+++ b/ConsoleSamples/Casino_Sample/CasinoSample.cs
@@ -1,0 +1,385 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ConsoleSamples.Casino_Sample
+{
+	public class CasinoSample : IConsoleSample
+	{
+		public void Run()
+		{
+			Console.WriteLine("Welcome to the Casino Sample.");
+			Console.WriteLine();
+
+			bool quit = false;
+			do
+			{
+				Console.WriteLine("Which fun activity would you like to do?");
+				Console.WriteLine("1. Simulate poker hand distributions");
+				Console.WriteLine("Q. Quit this sample");
+				Console.WriteLine("> ");
+				string userInput = Console.ReadLine();
+				switch (userInput.ToUpper())
+				{
+					case "1":
+						PokerHandDistributions();
+						break;
+					case "Q":
+						quit = true;
+						break;
+					default:
+						Console.WriteLine("ERROR: Invalid option!");
+						break;
+				}
+			} while (!quit);
+		}
+
+		public void PokerHandDistributions()
+		{
+			int numIterations = 100000;
+			bool printHands = false;
+			bool quit = false;
+			do
+			{
+				string simulation = null;
+				Console.WriteLine();
+				Console.WriteLine("Which simulation would you like to run?");
+				Console.WriteLine("1. Simple 5 random cards");
+				Console.WriteLine("2. Texas Hold 'em");
+				Console.WriteLine("3. 7-Card Mashup");
+				Console.WriteLine($"N. Set number of iterations [{numIterations} @ ~ {numIterations / 50000} secs]");
+				Console.WriteLine($"P. Toggle print of each hand [{printHands}]");
+				Console.WriteLine("Q. Quit this menu");
+				string userInput = Console.ReadLine();
+				switch (userInput.ToUpper())
+				{
+					case "1":
+						simulation = "5 cards";
+						break;
+					case "2":
+						simulation = "texas";
+						break;
+					case "3":
+						simulation = "7 card mashup";
+						break;
+					case "N":
+						Console.WriteLine("Enter the number of iterations: ");
+						userInput = Console.ReadLine();
+						numIterations = Convert.ToInt32(userInput);
+						break;
+					case "P":
+						printHands = !printHands;
+						break;
+					case "Q":
+						quit = true;
+						break;
+					default:
+						Console.WriteLine("ERROR: Invalid option!");
+						break;
+				}
+
+				if (simulation == "5 cards")
+				{
+					// Simple 5-card simulation.
+					Deck deckOfCards = new Deck();
+					//int[] Results = new int[10]; // index 9 is for chopped pots.
+					int[] HandRanks = new int[9]; // just the hand, not compared to another.
+					for (int iter = 0; iter < numIterations; iter++)
+					{
+						deckOfCards.Shuffle();
+						Card[] hand = new Card[5];
+						//Card[] handPlayer2 = new Card[5];
+						hand[0] = deckOfCards.Deal();
+						hand[1] = deckOfCards.Deal();
+						hand[2] = deckOfCards.Deal();
+						hand[3] = deckOfCards.Deal();
+						hand[4] = deckOfCards.Deal();
+						//handPlayer2[0] = deckOfCards.Deal();
+						//handPlayer2[1] = deckOfCards.Deal();
+						//handPlayer2[2] = deckOfCards.Deal();
+						//handPlayer2[3] = deckOfCards.Deal();
+						//handPlayer2[4] = deckOfCards.Deal();
+						int valudOfHand = PokerGame.EvaluateHand(hand);
+						HandRanks[valudOfHand >> 20]++;
+						//int valuePlayer2 = PokerGame.EvaluateHand(handPlayer2);
+						//HandRanks[valuePlayer2 >> 20]++;
+#if false
+						if (valudOfHand > valuePlayer2)
+						{
+							Results[valudOfHand >> 20]++;
+						}
+						else if (valuePlayer2 > valudOfHand)
+						{
+							Results[valuePlayer2 >> 20]++;
+						}
+						else
+						{
+							Results[9]++;
+						}
+#endif
+
+						if (printHands)
+						{
+							Console.Write("The hand that has been dealt: ");
+							foreach (Card card in hand)
+							{
+								Console.Write($"{card.Rank}{card.Suit} ");
+							}
+							Console.WriteLine($"which has a value of 0x{valudOfHand:X8}");
+#if false
+							Console.Write("Player 2 has been dealt: ");
+							foreach (Card card in handPlayer2)
+							{
+								Console.Write($"{card.Rank}{card.Suit} ");
+							}
+							Console.WriteLine($"which has a value of 0x{valuePlayer2:X8}");
+							if (valudOfHand > valuePlayer2)
+							{
+								Console.WriteLine("Player 1 wins!");
+							}
+							else if (valuePlayer2 > valudOfHand)
+							{
+								Console.WriteLine("Player 2 wins!");
+							}
+							else
+							{
+								Console.WriteLine("EVERYONE LOVES A CHOP POT!!!");
+							}
+#endif
+						}
+						else if (iter % 1000 == 0)
+							Console.Write(".");
+
+						// Don't forget to return the cards to the deck when the hand is over!
+						deckOfCards.Return(hand);
+						//deckOfCards.Return(handPlayer2);
+					}
+					decimal percent;
+					string[] strenghtNames = {
+						"High Card",
+						"One Pair",
+						"Two Pair",
+						"Three Of A Kind",
+						"Straight",
+						"Flush",
+						"Full House",
+						"Four Of A Kind",
+						"Straight Flush",
+						"Tie"};
+					Console.WriteLine("Simulation Results");
+					Console.WriteLine("==================");
+
+					Console.WriteLine("Hand Ranks");
+					Console.WriteLine("----------");
+					for (int idx = 0; idx < HandRanks.Length; idx++)
+					{
+						percent = Decimal.Divide(HandRanks[idx], numIterations);
+						Console.WriteLine("{0,-16} [{1,6:P1}] {2,10}",
+							strenghtNames[idx], percent, HandRanks[idx]);
+					}
+					Console.WriteLine();
+
+#if false
+					Console.WriteLine("Winning Hands");
+					Console.WriteLine("-------------");
+					for (int idx = 0; idx < Results.Length; idx++)
+					{
+						percent = Decimal.Divide(Results[idx], numIterations);
+						Console.WriteLine("{0,-16} [{1,6:P1}] {2,10}",
+							strenghtNames[idx], percent, Results[idx]);
+					}
+					Console.WriteLine();
+#endif
+				}
+
+				if (simulation == "texas")
+				{
+					// Texas Hold 'em simulation.
+					Deck deckOfCards = new Deck();
+					int[] HandRanks = new int[9]; // just the hand, not compared to another.
+					for (int iter = 0; iter < numIterations; iter++)
+					{
+						// Create the hand.
+						deckOfCards.Shuffle();
+						List<Card> hand = new List<Card>();
+						hand.Add(deckOfCards.Deal());
+						hand.Add(deckOfCards.Deal());
+						hand.Add(deckOfCards.Deal());
+						hand.Add(deckOfCards.Deal());
+						hand.Add(deckOfCards.Deal());
+						hand.Add(deckOfCards.Deal());
+						hand.Add(deckOfCards.Deal());
+
+						// Get the strength of the best 5-card hand.
+						int valueOfHand = PokerGame.GetBest_5From7_All21(hand);
+
+						// Increment the count for this ranking of hand.
+						HandRanks[valueOfHand >> 20]++;
+
+						if (printHands)
+						{
+							Console.Write("The hand that has been dealt: ");
+							foreach (Card card in hand)
+							{
+								Console.Write($"{card.Rank}{card.Suit} ");
+							}
+							Console.WriteLine($"which has a value of 0x{valueOfHand:X8}");
+						}
+						else if (iter % 1000 == 0)
+							Console.Write(".");
+
+						// Don't forget to return the cards to the deck when the hand is over!
+						deckOfCards.Return(hand);
+					}
+					decimal percent;
+					string[] strenghtNames = {
+						"High Card",
+						"One Pair",
+						"Two Pair",
+						"Three Of A Kind",
+						"Straight",
+						"Flush",
+						"Full House",
+						"Four Of A Kind",
+						"Straight Flush",
+						"Tie"};
+					Console.WriteLine();
+					Console.WriteLine("Simulation Results");
+					Console.WriteLine("==================");
+
+					Console.WriteLine("Hand Ranks");
+					Console.WriteLine("----------");
+					for (int idx = 0; idx < HandRanks.Length; idx++)
+					{
+						percent = Decimal.Divide(HandRanks[idx], numIterations);
+						Console.WriteLine("{0,-16} [{1,6:P1}] {2,10}",
+							strenghtNames[idx], percent, HandRanks[idx]);
+					}
+					Console.WriteLine();
+				}
+
+				if (simulation == "7 card mashup")
+				{
+					// All 7 cards are played simulation.
+					Deck deckOfCards = new Deck();
+					Dictionary<string, int> HandRanks = new Dictionary<string, int>();
+					HandRanks.Add("Flush7", 0);
+					HandRanks.Add("Flush6", 0);
+					HandRanks.Add("Flush5", 0);
+					HandRanks.Add("Straight7", 0);
+					HandRanks.Add("Straight6", 0);
+					HandRanks.Add("Straight5", 0);
+
+					// POC method; compare to existing method.
+					Dictionary<string, int> HandRanks2 = new Dictionary<string, int>();
+					HandRanks2.Add("StraightFlush7", 0);
+					HandRanks2.Add("StraightFlush6", 0);
+					HandRanks2.Add("StraightFlush5Pair", 0);
+					HandRanks2.Add("StraightFlush5", 0);
+					HandRanks2.Add("Flush7", 0);
+					HandRanks2.Add("Flush6", 0);
+					HandRanks2.Add("Flush5Pair", 0);
+					HandRanks2.Add("Flush5", 0);
+					HandRanks2.Add("Straight7", 0);
+					HandRanks2.Add("Straight6", 0);
+					HandRanks2.Add("Straight5Pair", 0);
+					HandRanks2.Add("Straight5", 0);
+					HandRanks2.Add("QuadSet", 0);
+					HandRanks2.Add("QuadPair", 0);
+					HandRanks2.Add("Quad", 0);
+					HandRanks2.Add("SetSet", 0);
+					HandRanks2.Add("SetPairPair", 0);
+					HandRanks2.Add("SetPair", 0);
+					HandRanks2.Add("Set", 0);
+					HandRanks2.Add("PairPairPair", 0);
+					HandRanks2.Add("PairPair", 0);
+					HandRanks2.Add("Pair", 0);
+					HandRanks2.Add("HighCard", 0);
+
+					List<string> pocResults;
+					for (int iter = 0; iter < numIterations; iter++)
+					{
+						// Create the hand.
+						deckOfCards.Shuffle();
+						List<Card> hand = new List<Card>();
+						hand.Add(deckOfCards.Deal());
+						hand.Add(deckOfCards.Deal());
+						hand.Add(deckOfCards.Deal());
+						hand.Add(deckOfCards.Deal());
+						hand.Add(deckOfCards.Deal());
+						hand.Add(deckOfCards.Deal());
+						hand.Add(deckOfCards.Deal());
+						hand.Sort();
+						hand.Reverse();
+
+#if false
+						// not sure how to evaluate this yet, so start small.
+						int flushLen = PokerGame.LargestFlush(hand);
+						if (flushLen == 7)
+							HandRanks["Flush7"]++;
+						else if (flushLen == 6)
+							HandRanks["Flush6"]++;
+						else if (flushLen == 5)
+							HandRanks["Flush5"]++;
+
+						int straightLen = PokerGame.LargestStraight(hand);
+						if (straightLen == 7)
+							HandRanks["Straight7"]++;
+						else if (straightLen == 6)
+							HandRanks["Straight6"]++;
+						else if (straightLen == 5)
+							HandRanks["Straight5"]++;
+#endif
+						// POC new method
+						pocResults = PokerGame.PocNewMethodFor7Cards(hand);
+						foreach (string res in pocResults)
+							HandRanks2[res]++;
+
+						if (printHands)
+						{
+							foreach (Card card in hand)
+							{
+								Console.Write($"{card.Rank}{card.Suit} ");
+							}
+							//Console.Write($"{straightLen}_str8 ");
+							//Console.Write($"{flushLen}_flush ");
+							foreach (string res in pocResults)
+								Console.Write($"{res} ");
+							Console.WriteLine();
+						}
+						else if (iter % 50000 == 0)
+							Console.Write(".");
+
+						// Don't forget to return the cards to the deck when the hand is over!
+						deckOfCards.Return(hand);
+					}
+					Console.WriteLine();
+					Console.WriteLine("Simulation Results");
+					Console.WriteLine("==================");
+
+					Console.WriteLine("Hand Ranks");
+					Console.WriteLine("----------");
+					decimal percent;
+#if false
+					foreach (var key in HandRanks)
+					{
+						percent = Decimal.Divide(key.Value, numIterations);
+						Console.WriteLine($"{key.Key} [{percent:P1}] {key.Value}");
+					}
+					Console.WriteLine();
+#endif
+					Console.WriteLine("Using the new method");
+					var ordered = HandRanks2.OrderBy(x => x.Value);
+					foreach (var key in ordered)
+					{
+						percent = Decimal.Divide(key.Value, numIterations);
+						Console.WriteLine($"{key.Key,25} [{percent,5:P1}] {key.Value}");
+					}
+					Console.WriteLine();
+				}
+			} while (!quit);
+		}
+
+	}
+}

--- a/ConsoleSamples/Casino_Sample/Deck.cs
+++ b/ConsoleSamples/Casino_Sample/Deck.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ConsoleSamples.Casino_Sample
+{
+	public class Deck
+	{
+		public List<Card> Cards;
+
+		public Card Deal()
+		{
+			Card theCard = Cards[0];
+			Cards.RemoveAt(0);
+			return theCard;
+		}
+
+		/// <summary>
+		/// Returns the given cards to the bottom of the deck.
+		/// </summary>
+		/// <param name="cards">The cards to return.</param>
+		public void Return(Card[] cards)
+		{
+			foreach (Card card in cards)
+			{
+				this.Cards.Add(card);
+			}
+		}
+
+		/// <summary>
+		/// Returns the given cards to the bottom of the deck.
+		/// </summary>
+		/// <param name="cards">The cards to return.</param>
+		public void Return(List<Card> cards)
+		{
+			foreach (Card card in cards)
+			{
+				this.Cards.Add(card);
+			}
+		}
+
+		public void Shuffle()
+		{
+			List<Card> target = new List<Card>();
+
+			Random rng = new Random();
+			while (Cards.Count > 0)
+			{
+				int rand = rng.Next(Cards.Count);
+				Card selectedCard = Cards[rand];
+				target.Add(selectedCard);
+				Cards.RemoveAt(rand);
+			}
+
+			Cards = target;
+		}
+
+		public Deck()
+		{
+			Cards = new List<Card>();
+
+			// Create a standard 52-card deck.
+			// Order is Spades then Diamonds (A - K), then
+			// Clubs then Hearts (K - A).
+			string suit;
+
+			// Spades
+			suit = "s";
+			//			Cards.Add(new Card("A", suit));
+			Cards.Add(new Card()); // default card is the Ace Of Spades.
+			for (int x = 2; x < 10; x++)
+			{
+				Cards.Add(new Card(x.ToString(), suit));
+			}
+			Cards.Add(new Card("T", suit));
+			Cards.Add(new Card("J", suit));
+			Cards.Add(new Card("Q", suit));
+			Cards.Add(new Card("K", suit));
+
+			// Diamonds
+			suit = "d";
+			Cards.Add(new Card("A", suit));
+			for (int x = 2; x < 10; x++)
+			{
+				Cards.Add(new Card(x.ToString(), suit));
+			}
+			Cards.Add(new Card("T", suit));
+			Cards.Add(new Card("J", suit));
+			Cards.Add(new Card("Q", suit));
+			Cards.Add(new Card("K", suit));
+
+			// Clubs
+			suit = "c";
+			Cards.Add(new Card("K", suit));
+			Cards.Add(new Card("Q", suit));
+			Cards.Add(new Card("J", suit));
+			Cards.Add(new Card("T", suit));
+			for (int x = 9; x > 1; x--)
+			{
+				Cards.Add(new Card(x.ToString(), suit));
+			}
+			Cards.Add(new Card("A", suit));
+
+			// Hearts
+			suit = "h";
+			Cards.Add(new Card("K", suit));
+			Cards.Add(new Card("Q", suit));
+			Cards.Add(new Card("J", suit));
+			Cards.Add(new Card("T", suit));
+			for (int x = 9; x > 1; x--)
+			{
+				Cards.Add(new Card(x.ToString(), suit));
+			}
+			Cards.Add(new Card("A", suit));
+		}
+	}
+}

--- a/ConsoleSamples/Casino_Sample/PokerGame.cs
+++ b/ConsoleSamples/Casino_Sample/PokerGame.cs
@@ -1,0 +1,893 @@
+﻿using Google.Apis.Docs.v1.Data;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ConsoleSamples.Casino_Sample
+{
+	public class PokerGame
+	{
+		/// <summary>
+		/// Returns the strength of the given hand.
+		/// </summary>
+		/// <param name="Hand"></param>
+		/// <returns>An int representing the strength of the hand.</returns>
+		/// Hand Ranking Encoding:
+		/// straight flush [highest card]
+		/// [+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+]
+		/// [+   reserved    +   8   +  RH   +  RMH  +  RM   +  RML  +  RL   +]
+		/// four of a kind [common rank][kicker]
+		/// [+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+]
+		/// [+   reserved    +   7   +  QV   +  QV   +  QV   +  QV   +  RH   +]
+		/// full house [three-card rank][two-card rank]
+		/// [+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+]
+		/// [+   reserved    +   6   +  TV   +  TV   +  TV   +  PV   +  PV   +]
+		/// flush [rank of each card from highest to lowest]
+		/// [+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+]
+		/// [+   reserved    +   5   +  RH   +  RMH  +  RM   +  RML  +  RL   +]
+		/// straight [highest card]
+		/// [+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+]
+		/// [+   reserved    +   4   +  RH   +  RMH  +  RM   +  RML  +  RL   +]
+		/// three of a kind [common rank][higher kicker][lower kicker]
+		/// [+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+]
+		/// [+   reserved    +   3   +  TV   +  TV   +  TV   +  RH   +  RL   +]
+		/// two pair [higher pair rank][lower pair rank][kicker]
+		/// [+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+]
+		/// [+   reserved    +   2   +  PH   +  PH   +  PL   +  PL   +  RH   +]
+		/// one pair [pair rank][highest kicker][middle kicker][lowest kicker]
+		/// [+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+]
+		/// [+   reserved    +   1   +  PV   +  PV   +  RH   +  RM   +  RL   +]
+		/// high card [rank of each card from highest to lowest]
+		/// [+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+]
+		/// [+   reserved    +   0   +  RH   +  RMH  +  RM   +  RML  +  RL   +]
+		public static int EvaluateHand(Card[] Hand)
+		{
+			const int StraightFlush = 0x00800000;
+			const int FourOfAKind = 0x00700000;
+			const int FullHouse = 0x00600000;
+			const int Flush = 0x00500000;
+			const int Straight = 0x00400000;
+			const int ThreeOfAKind = 0x00300000;
+			const int TwoPair = 0x00200000;
+			const int OnePair = 0x00100000;
+			const int HighCard = 0x00000000;
+			int strength = -1;
+
+			// Check for flush
+			bool flush = false;
+			if (Hand[0].Suit == Hand[1].Suit &&
+				Hand[0].Suit == Hand[2].Suit &&
+				Hand[0].Suit == Hand[3].Suit &&
+				Hand[0].Suit == Hand[4].Suit)
+				flush = true;
+
+			// Check for straight
+			bool straight = false;
+			bool wheel = false;
+			// NOTE: This sorts by rank from low to high, even though
+			// we think of poker hands as going from high to low.
+			Array.Sort(Hand);
+			if (Hand[0].RankValue == Hand[1].RankValue - 1 &&
+				Hand[1].RankValue == Hand[2].RankValue - 1 &&
+				Hand[2].RankValue == Hand[3].RankValue - 1)
+			{
+				// Normal case
+				if (Hand[3].RankValue == Hand[4].RankValue - 1)
+					straight = true;
+				// Ace-low (i.e. the wheel) case
+				if (Hand[0].RankValue == 2 && Hand[4].RankValue == 14)
+				{
+					straight = true;
+					wheel = true;
+				}
+			}
+
+			// Are we a straight flush?
+			if (flush && straight)
+			{
+				strength = StraightFlush;
+				if (wheel)
+				{
+					strength |= (Hand[3].RankValue << 16);
+					strength |= (Hand[2].RankValue << 12);
+					strength |= (Hand[1].RankValue << 8);
+					strength |= (Hand[0].RankValue << 4);
+					strength |= (1 << 0); // Ace == 1 when it is low
+				}
+				else
+				{
+					strength |= (Hand[4].RankValue << 16);
+					strength |= (Hand[3].RankValue << 12);
+					strength |= (Hand[2].RankValue << 8);
+					strength |= (Hand[1].RankValue << 4);
+					strength |= (Hand[0].RankValue << 0);
+				}
+
+				return strength;
+			}
+
+			// Are we a flush?
+			if (flush)
+			{
+				strength = Flush;
+				strength |= (Hand[4].RankValue << 16);
+				strength |= (Hand[3].RankValue << 12);
+				strength |= (Hand[2].RankValue << 8);
+				strength |= (Hand[1].RankValue << 4);
+				strength |= (Hand[0].RankValue << 0);
+
+				return strength;
+			}
+
+			// Are we a straight?
+			if (straight)
+			{
+				strength = Straight;
+				if (wheel)
+				{
+					strength |= (Hand[3].RankValue << 16);
+					strength |= (Hand[2].RankValue << 12);
+					strength |= (Hand[1].RankValue << 8);
+					strength |= (Hand[0].RankValue << 4);
+					strength |= (1 << 0); // Ace == 1 when it is low
+				}
+				else
+				{
+					strength |= (Hand[4].RankValue << 16);
+					strength |= (Hand[3].RankValue << 12);
+					strength |= (Hand[2].RankValue << 8);
+					strength |= (Hand[1].RankValue << 4);
+					strength |= (Hand[0].RankValue << 0);
+				}
+
+				return strength;
+			}
+
+			// Count matches to see if we have 2/3/4-of-a-kind.
+			// Only look forward.
+			// # Matches  Hand
+			// ===============
+			// 6  - Quads
+			// 4  - Boat
+			// 3  - Trips
+			// 2  - 2 Pair
+			// 1  - Pair
+			// 0  - High Card
+			int numMatches = 0;
+			for (int i = 0; i < 4; i++)
+			{
+				for (int j = i + 1; j < 5; j++)
+				{
+					if (Hand[i].RankValue == Hand[j].RankValue)
+						numMatches++;
+				}
+			}
+
+			// Are we four-of-a-kind?
+			if (numMatches == 6)
+			{
+				strength = FourOfAKind;
+				if (Hand[0].RankValue == Hand[1].RankValue)
+				{
+					// e.g. 22223
+					strength |= (Hand[0].RankValue << 16);
+					strength |= (Hand[0].RankValue << 12);
+					strength |= (Hand[0].RankValue << 8);
+					strength |= (Hand[0].RankValue << 4);
+					strength |= (Hand[4].RankValue << 0);
+				}
+				else
+				{
+					// e.g. 23333
+					strength |= (Hand[1].RankValue << 16);
+					strength |= (Hand[1].RankValue << 12);
+					strength |= (Hand[1].RankValue << 8);
+					strength |= (Hand[1].RankValue << 4);
+					strength |= (Hand[0].RankValue << 0);
+				}
+			}
+			// Are we a full house?
+			else if (numMatches == 4)
+			{
+				strength = FullHouse;
+
+				// Once sorted, the third card gives the bigger side.
+				if (Hand[2].RankValue == Hand[1].RankValue)
+				{
+					strength |= Hand[0].RankValue << 16;
+					strength |= Hand[1].RankValue << 12;
+					strength |= Hand[2].RankValue << 8;
+					strength |= Hand[3].RankValue << 4;
+					strength |= Hand[4].RankValue << 0;
+				}
+				else
+				{
+					strength |= Hand[2].RankValue << 16;
+					strength |= Hand[3].RankValue << 12;
+					strength |= Hand[4].RankValue << 8;
+					strength |= Hand[0].RankValue << 4;
+					strength |= Hand[1].RankValue << 0;
+				}
+			}
+			// Are we three of a kind?
+			else if (numMatches == 3)
+			{
+				strength = ThreeOfAKind;
+
+				// Once sorted, there are three possibiliies:
+				// XXXyz, yXXXz, yzXXX.
+				// Therefore, the third card is always a part of
+				// the trips.
+				int tripRank = Hand[2].RankValue;
+				if (Hand[0].RankValue == tripRank)
+				{
+					strength |= tripRank << 16;
+					strength |= tripRank << 12;
+					strength |= tripRank << 8;
+					strength |= Hand[4].RankValue << 4;
+					strength |= Hand[3].RankValue << 0;
+				}
+				else if (Hand[4].RankValue == tripRank)
+				{
+					strength |= tripRank << 16;
+					strength |= tripRank << 12;
+					strength |= tripRank << 8;
+					strength |= Hand[1].RankValue << 4;
+					strength |= Hand[0].RankValue << 0;
+				}
+				else
+				{
+					strength |= tripRank << 16;
+					strength |= tripRank << 12;
+					strength |= tripRank << 8;
+					strength |= Hand[4].RankValue << 4;
+					strength |= Hand[0].RankValue << 0;
+				}
+			}
+			// Are we two pair?
+			else if (numMatches == 2)
+			{
+				strength = TwoPair;
+
+				// Once sorted, there are three possibiliies:
+				// zLLHH, LLHHz, LLzHH.
+				if (Hand[0].RankValue != Hand[1].RankValue)
+				{
+					strength |= Hand[3].RankValue << 16;
+					strength |= Hand[4].RankValue << 12;
+					strength |= Hand[1].RankValue << 8;
+					strength |= Hand[2].RankValue << 4;
+					strength |= Hand[0].RankValue << 0;
+				}
+				else if (Hand[4].RankValue != Hand[3].RankValue)
+				{
+					strength |= Hand[2].RankValue << 16;
+					strength |= Hand[3].RankValue << 12;
+					strength |= Hand[0].RankValue << 8;
+					strength |= Hand[1].RankValue << 4;
+					strength |= Hand[4].RankValue << 0;
+				}
+				else
+				{
+					strength |= Hand[3].RankValue << 16;
+					strength |= Hand[4].RankValue << 12;
+					strength |= Hand[0].RankValue << 8;
+					strength |= Hand[1].RankValue << 4;
+					strength |= Hand[2].RankValue << 0;
+				}
+			}
+			// Are we one pair?
+			else if (numMatches == 1)
+			{
+				strength = OnePair;
+
+				// Once sorted, there are four possibiliies:
+				// PPxyz, xPPyz, xyPPz, xyzPP
+				if (Hand[0].RankValue == Hand[1].RankValue)
+				{
+					strength |= Hand[0].RankValue << 16;
+					strength |= Hand[1].RankValue << 12;
+					strength |= Hand[4].RankValue << 8;
+					strength |= Hand[3].RankValue << 4;
+					strength |= Hand[2].RankValue << 0;
+				}
+				else if (Hand[1].RankValue == Hand[2].RankValue)
+				{
+					strength |= Hand[1].RankValue << 16;
+					strength |= Hand[2].RankValue << 12;
+					strength |= Hand[4].RankValue << 8;
+					strength |= Hand[3].RankValue << 4;
+					strength |= Hand[0].RankValue << 0;
+				}
+				else if (Hand[2].RankValue == Hand[3].RankValue)
+				{
+					strength |= Hand[2].RankValue << 16;
+					strength |= Hand[3].RankValue << 12;
+					strength |= Hand[4].RankValue << 8;
+					strength |= Hand[1].RankValue << 4;
+					strength |= Hand[0].RankValue << 0;
+				}
+				else
+				{
+					strength |= Hand[3].RankValue << 16;
+					strength |= Hand[4].RankValue << 12;
+					strength |= Hand[2].RankValue << 8;
+					strength |= Hand[1].RankValue << 4;
+					strength |= Hand[0].RankValue << 0;
+				}
+			}
+			// Are we high card?
+			else if (numMatches == 0)
+			{
+				// The cards are already sorted for us, we just need
+				// to reverse the order to match what the caller expects.
+				strength = HighCard;
+				strength |= Hand[4].RankValue << 16;
+				strength |= Hand[3].RankValue << 12;
+				strength |= Hand[2].RankValue << 8;
+				strength |= Hand[1].RankValue << 4;
+				strength |= Hand[0].RankValue << 0;
+			}
+			else
+			{
+				// TODO: What type of exception should be thrown here?
+				throw new Exception();
+			}
+
+			return strength;
+		}
+
+		static public int GetBest_5From7_All21(List<Card> cards)
+		{
+			int strength = -1;
+
+			// Create all possible 5-card hands from the 7 we have to work with.
+			List<List<Card>> allCombos = GetCombos(cards, 5);
+
+			// Calculate the strength of each combo.
+			foreach (List<Card> combo in allCombos)
+			{
+				int comboStr = EvaluateHand(combo.ToArray());
+				if (comboStr > strength)
+				{
+					strength = comboStr;
+				}
+			}
+
+			return strength;
+		}
+		static public int GetNumDistinctRanks(List<Card> cards)
+		{
+			int num = 0;
+			int[] rankQty = new int[15]; // 0 and 1 are not used, but so what?
+			foreach (Card card in cards)
+			{
+				rankQty[card.RankValue]++;
+			}
+			foreach (int val in rankQty)
+				if (val > 0)
+					num++;
+
+			return num;
+		}
+
+		static public bool IsStraight(List<Card> cards)
+		{
+			if (cards == null || cards.Count == 0)
+				return false;
+			if (cards.Count == 1)
+				return true;
+
+			bool temp = true;
+			for (int idx = 0; idx < cards.Count - 1; idx++)
+				if (cards[idx].RankValue != cards[idx + 1].RankValue + 1)
+					temp = false;
+
+			if (temp)
+				return true;
+
+			// Special Case: The Wheel may still be possible.
+			if (cards[0].Rank == "A")
+			{
+				List<Card> subset = cards.GetRange(1, cards.Count - 1);
+				if (cards.Last().Rank == "2" && IsStraight(subset))
+					return true;
+			}
+
+			return false;
+		}
+
+		static public List<List<Card>> GetCombos(List<Card> input, int n)
+		{
+			List<List<Card>> combos = new List<List<Card>>();
+
+			if (n == 1)
+			{
+				foreach (Card card in input)
+				{
+					List<Card> newCombo = new List<Card>();
+					newCombo.Add(card);
+					combos.Add(newCombo);
+				}
+			}
+			else
+			{
+				for (int i = 0; i < input.Count - 1; i++)
+				{
+					List<Card> tail = input.GetRange(i + 1, input.Count - i - 1);
+					List<List<Card>> subCombos = GetCombos(tail, n - 1);
+					foreach (List<Card> combo in subCombos)
+					{
+						List<Card> newCombo = new List<Card>();
+						newCombo.Add(input[i]);
+						foreach (Card card in combo)
+							newCombo.Add(card);
+						//string combo = input[i] + combo;
+						combos.Add(newCombo);
+					}
+				}
+			}
+
+			return combos;
+		}
+
+		/// <summary>
+		/// (Assumes cards are sorted from Ace to 2).
+		/// </summary>
+		/// <param name="cards">The set of cards to examine.</param>
+		/// <returns></returns>
+		static public int LargestFlush(List<Card> cards)
+		{
+			Dictionary<string, int> suitQty = new Dictionary<string, int>();
+			suitQty.Add("c", 0);
+			suitQty.Add("d", 0);
+			suitQty.Add("h", 0);
+			suitQty.Add("s", 0);
+			foreach (Card card in cards)
+			{
+				suitQty[card.Suit]++;
+			}
+			int longest = 0;
+			foreach (var item in suitQty)
+				if (item.Value > longest)
+					longest = item.Value;
+
+			return longest;
+		}
+
+		/// <summary>
+		/// (Assumes cards are sorted from Ace to 2).
+		/// </summary>
+		/// <param name="cards">The set of cards to examine.</param>
+		/// <returns></returns>
+		static public int LargestStraight(List<Card> cards)
+		{
+			int longest = 0;
+
+			int[] ranks = new int[15]; // 0 is unused; too messy to do -1 everywhere
+			foreach (Card card in cards)
+				ranks[card.RankValue]++;
+			// Aces can also be "1".
+			ranks[1] = ranks[14];
+			int run = 0;
+			for (int i = 1; i < 15; i++)
+			{
+				if (ranks[i] > 0)
+				{
+					run++;
+					if (run > longest)
+						longest = run;
+				}
+				else
+					run = 0;
+			}
+			return longest;
+		}
+
+		static public List<string> PocNewMethodFor7Cards(List<Card> cards)
+		{
+			List<string> results = new List<string>();
+
+			// For flushes.
+			Dictionary<string, int> suitQty = new Dictionary<string, int>
+			{
+				{ "c", 0 },
+				{ "d", 0 },
+				{ "h", 0 },
+				{ "s", 0 }
+			};
+			List<Card> clubs = new List<Card>();
+			List<Card> diamonds = new List<Card>();
+			List<Card> hearts = new List<Card>();
+			List<Card> spades = new List<Card>();
+			// For straights and matches.
+			int[] ranks = new int[15]; // 0 is unused; too messy to do -1 everywhere
+									   // For matches.
+			int numPair = 0;
+			int numSet = 0;
+			int numQuad = 0;
+
+			// Scan through the cards looking for items of interest.
+			foreach (Card card in cards)
+			{
+				// Suit count for flush.
+				suitQty[card.Suit]++;
+				switch (card.Suit)
+				{
+					case "c":
+						clubs.Add(card);
+						break;
+					case "d":
+						diamonds.Add(card);
+						break;
+					case "h":
+						hearts.Add(card);
+						break;
+					case "s":
+						spades.Add(card);
+						break;
+				}
+
+				// Track ranks for both straights and matches.
+				ranks[card.RankValue]++;
+				// Check for new match.
+				if (ranks[card.RankValue] == 2)
+					numPair++;
+				else if (ranks[card.RankValue] == 3)
+				{
+					numPair--;
+					numSet++;
+				}
+				else if (ranks[card.RankValue] == 4)
+				{
+					numSet--;
+					numQuad++;
+				}
+			}
+
+			// Find the longest flush.
+			int longestFlush = 0;
+			string longestFlushSuit = "";
+			foreach (var item in suitQty)
+				if (item.Value > longestFlush)
+				{
+					longestFlush = item.Value;
+					longestFlushSuit = item.Key;
+				}
+
+			// Find the longest straight.
+			int longestStraight = 0;
+			int runLen = 0;
+			int runHighestRank = 0;
+			ranks[1] = ranks[14];
+			for (int i = 1; i < 15; i++)
+			{
+				if (ranks[i] > 0)
+				{
+					runLen++;
+					if (runLen > longestStraight)
+					{
+						longestStraight = runLen;
+						runHighestRank = i;
+					}
+				}
+				else
+					runLen = 0;
+			}
+
+			// There are two categories of value in a poker hand:
+			// "run" (flush, straight) and "match" (pair, set, quad).
+			// Check for a run first, because it is (or should be) rarer.
+			if (longestFlush >= 5 || longestStraight >= 5)
+			{
+				// Start with flushes.
+				// Within the flush category we will look for straight flushes as well.
+				// This means we don't need to look for them in the straight category.
+				if (longestFlush == 7)
+				{
+					// With all cards being the same suit, there can be no "matches",
+					// so no need to look for them.
+					if (longestStraight == 7)
+						// StrFl7 is a superset of Fl7 so don't include it.
+						results.Add("StraightFlush7");
+					else
+					{
+						results.Add("Flush7");
+						if (longestStraight == 6)
+							results.Add("StraightFlush6");
+						else if (longestStraight == 5)
+							results.Add("StraightFlush5"); // can't be StraightFlush5Pair
+					}
+				}
+				else if (longestFlush == 6)
+				{
+					results.Add("Flush6");
+					// First look for straight flushes.
+					int strFlushLen = 0;
+					List<Card> flushCards = null;
+					switch (longestFlushSuit)
+					{
+						case "c":
+							strFlushLen = LargestStraight(clubs);
+							flushCards = clubs;
+							break;
+						case "d":
+							strFlushLen = LargestStraight(diamonds);
+							flushCards = diamonds;
+							break;
+						case "h":
+							strFlushLen = LargestStraight(hearts);
+							flushCards = hearts;
+							break;
+						case "s":
+							strFlushLen = LargestStraight(spades);
+							flushCards = spades;
+							break;
+					}
+					List<Card> notFlushCards = cards.Except(flushCards).ToList();
+					if (strFlushLen == 6)
+					{
+						// StrFl6 is a superset of Flush6, so remove it.
+						results.Remove("Flush6");
+						results.Add("StraightFlush6");
+
+						// We have a StrFl6, but do we also have a StrFl5 + Pair?
+						// Only the first and last cards of the StrFl are eligible for
+						// pairing, because only they can be removed and still maintain
+						// the StrFl5.
+
+						// Check for The Wheel.
+						if (flushCards[0].RankValue == 14 && flushCards[1].RankValue != 13)
+						{
+							// The Wheel case.
+							if (flushCards[0].RankValue == notFlushCards[0].RankValue ||
+								flushCards[1].RankValue == notFlushCards[0].RankValue)
+							{
+								results.Add("StraightFlush5Pair");
+							}
+						}
+						else
+						{
+							// The non-wheel case.
+							if (flushCards[0].RankValue == notFlushCards[0].RankValue ||
+								flushCards[5].RankValue == notFlushCards[0].RankValue)
+							{
+								results.Add("StraightFlush5Pair");
+							}
+						}
+					}
+					else if (strFlushLen == 5)
+					{
+						// Can we form a Pair with the suited card that isn't part of our
+						// StrFl5 and the non-suited card?
+
+						// High-end StrFl5 (EX: AKQJT2)
+						if (flushCards[0].RankValue == (flushCards[1].RankValue + 1) &&
+							flushCards[5].RankValue == notFlushCards[0].RankValue)
+						{
+							results.Add("StraightFlush5Pair");
+						}
+						// The Wheel (EX: AK5432)
+						else if (flushCards[0].RankValue == 14 &&
+							flushCards[1].RankValue == notFlushCards[0].RankValue)
+						{
+							results.Add("StraightFlush5Pair");
+						}
+						// Low-end StrFl5 (EX: T87654)
+						else if (flushCards[0].RankValue == notFlushCards[0].RankValue)
+						{
+							results.Add("StraightFlush5Pair");
+						}
+						// No Pair to go with the StrFl5.
+						else
+							results.Add("StraightFlush5");
+					}
+					else
+					{
+						// We do not have a straight flush withing our 6 suited cards.
+
+						// If one of our suited cards pairs the non-suited cards,
+						// then we also have a Flush5Pair.
+						foreach (Card card in flushCards)
+							if (card.RankValue == notFlushCards[0].RankValue)
+							{
+								results.Add("Flush5Pair");
+								break;
+							}
+					}
+				}
+				else if (longestFlush == 5)
+				{
+					// First look for straight flushes.
+					int strFlushLen = 0;
+					List<Card> flushCards = null;
+					switch (longestFlushSuit)
+					{
+						case "c":
+							strFlushLen = LargestStraight(clubs);
+							flushCards = clubs;
+							break;
+						case "d":
+							strFlushLen = LargestStraight(diamonds);
+							flushCards = diamonds;
+							break;
+						case "h":
+							strFlushLen = LargestStraight(hearts);
+							flushCards = hearts;
+							break;
+						case "s":
+							strFlushLen = LargestStraight(spades);
+							flushCards = spades;
+							break;
+					}
+					List<Card> notFlushCards = cards.Except(flushCards).ToList();
+					if (strFlushLen == 5)
+					{
+						// If the non-suited cards are of the same rank,
+						// then we also have a StraightFlush5Pair.
+						if (notFlushCards[0].RankValue == notFlushCards[1].RankValue)
+						{
+							results.Add("StraightFlush5Pair");
+						}
+						// No Pair to go with the StrFl5.
+						else
+							results.Add("StraightFlush5");
+					}
+					else
+					{
+						// Not a straight flush.
+						// If the non-suited cards are of the same rank,
+						// then we have a Flush5Pair; otherwise just Flush5.
+						if (notFlushCards[0].RankValue == notFlushCards[1].RankValue)
+							results.Add("Flush5Pair");
+						else
+							results.Add("Flush5");
+					}
+				}
+
+				// Now look for straights.
+				// At this point all flush combinations have been identified, so
+				// there is no need to look for them here.
+				if (longestStraight == 7 && !results.Contains("StraightFlush7"))
+					results.Add("Straight7");
+				else if (longestStraight == 6)
+				{
+					// Don't count Str6 if we have already identified StrFl6.
+					if (!results.Contains("StraightFlush6"))
+						results.Add("Straight6");
+
+					// If either of the end cards matches the 7th card then we also
+					// have a Str5Pair.
+					// However, if we have already identified a StrFl5Pair then
+					// there is no need to proceed, since a Str5Pair is a subset
+					// (in the same way that we are not also reporting Flush5Pair).
+					if (!results.Contains("StraightFlush5Pair"))
+					{
+						// Create a collection of the cards used in the straight.
+						// Because we have already accounted for flushes, the suit
+						// doesn't matter (no need to worry about breaking up a StrFl).
+						int runLowestRank;
+						if (runHighestRank == 6)
+							runLowestRank = 2; // Ace is 14, not 1, which would kill our loop
+						else
+							runLowestRank = runHighestRank - 5;
+						List<Card> straightCards = new List<Card>();
+						for (int i = runHighestRank; i >= runLowestRank; i--)
+						{
+							straightCards.Add(cards.Find(c => c.RankValue == i));
+						}
+						if (runHighestRank == 6)
+						{
+							// We know the first card must be an Ace.
+							straightCards.Add(cards[0]);
+						}
+
+						// Get the card that isn't in the straight.
+						List<Card> notStraightCards = cards.Except(straightCards).ToList();
+
+						// Compare that card to the endpoints of the straight.
+						if (straightCards[0].RankValue == notStraightCards[0].RankValue ||
+							straightCards[5].RankValue == notStraightCards[0].RankValue)
+							results.Add("Straight5Pair");
+					}
+				}
+				else if (longestStraight == 5)
+				{
+					// If we have already found a StrFl5 or StrFl5Pair, then
+					// there is nothing new to find.
+					if (!results.Contains("StraightFlush5") &&
+						!results.Contains("StraightFlush5Pair"))
+					{
+						bool str5Pair = false;
+
+						// Might also have a Pair, so check the two that aren't involved.
+						int possiblePairRank = -1;
+
+						// If it is a straight to the 5, then it is The Wheel, which
+						// means that the first card (at least) is an Ace. Pop it off
+						// the beginning of the list and put it at the end.
+						if (runHighestRank == 5)
+						{
+							Card ace = cards[0];
+							cards.RemoveAt(0);
+							cards.Add(ace);
+						}
+
+						for (int i = 0; i < 7; i++)
+						{
+							if (cards[i].RankValue == runHighestRank)
+							{
+								// This card is part of the straight, so we are not interested.
+								// We are now looking for the next-lowest rank.
+								runHighestRank--;
+								// Handle The Wheel.
+								if (runHighestRank == 1)
+									runHighestRank = 14;
+							}
+							else
+							{
+								// This card is not part of the straight.
+								// If this is the first such card we have encountered, remember its rank.
+								if (possiblePairRank == -1)
+									possiblePairRank = cards[i].RankValue;
+								else if (possiblePairRank == cards[i].RankValue)
+								{
+									results.Add("Straight5Pair");
+									str5Pair = true;
+								}
+							}
+						}
+
+						// Straight5 is a subset of Straight5Pair, so don't allow both.
+						if (!str5Pair)
+							results.Add("Straight5");
+					}
+				}
+				return results;
+			}
+
+			// Now we can handle matches.
+			// Try some funky math to make things simpler/faster???
+			int value = numQuad * 16 + numSet * 4 + numPair;
+			switch (value)
+			{
+				case 20:
+					results.Add("QuadSet");
+					break;
+				case 17:
+					results.Add("QuadPair");
+					break;
+				case 16:
+					results.Add("Quad");
+					break;
+				case 8:
+					results.Add("SetSet");
+					break;
+				case 6:
+					results.Add("SetPairPair");
+					break;
+				case 5:
+					results.Add("SetPair");
+					break;
+				case 4:
+					results.Add("Set");
+					break;
+				case 3:
+					results.Add("PairPairPair");
+					break;
+				case 2:
+					results.Add("PairPair");
+					break;
+				case 1:
+					results.Add("Pair");
+					break;
+				default:
+					results.Add("HighCard");
+					break;
+			}
+
+			return results;
+		}
+	}
+}

--- a/ConsoleSamples/Program.cs
+++ b/ConsoleSamples/Program.cs
@@ -1,7 +1,10 @@
-﻿using ConsoleSamples.EF_Relationship_Sample;
+﻿using ConsoleSamples.Casino_Sample;
+using ConsoleSamples.EF_Relationship_Sample;
 using ConsoleSamples.Finance_Sample;
 using ConsoleSamples.Google_Docs_API;
+using Google.Apis.Docs.v1.Data;
 using System;
+using System.Collections.Generic;
 
 namespace ConsoleSamples
 {
@@ -19,6 +22,7 @@ namespace ConsoleSamples
 				Console.WriteLine("1. Google Docs API");
 				Console.WriteLine("2. EF Relationships");
 				Console.WriteLine("3. Finance");
+				Console.WriteLine("4. Casino Games");
 
 				Console.WriteLine("Q. Quit");
 
@@ -34,6 +38,9 @@ namespace ConsoleSamples
 						break;
 					case "3":
 						sample = new FinanceSample();
+						break;
+					case "4":
+						sample = new CasinoSample();
 						break;
 					case "q":
 						quit = true;

--- a/UnitTests/UT_PokerGame.cs
+++ b/UnitTests/UT_PokerGame.cs
@@ -1,0 +1,3088 @@
+﻿using ConsoleSamples.Casino_Sample;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Xml.Serialization;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace UnitTests
+{
+	public class GamingFixture
+	{
+		static public Card AceOfSpades = new Card("A", "s");
+		static public Card KingOfSpades = new Card("K", "s");
+		static public Card QueenOfSpades = new Card("Q", "s");
+		static public Card JackOfSpades = new Card("J", "s");
+		static public Card TenOfSpades = new Card("T", "s");
+		static public Card NineOfSpades = new Card("9", "s");
+		static public Card EightOfSpades = new Card("8", "s");
+		static public Card SevenOfSpades = new Card("7", "s");
+		static public Card SixOfSpades = new Card("6", "s");
+		static public Card FiveOfSpades = new Card("5", "s");
+		static public Card FourOfSpades = new Card("4", "s");
+		static public Card ThreeOfSpades = new Card("3", "s");
+		static public Card TwoOfSpades = new Card("2", "s");
+
+		static public Card AceOfHearts = new Card("A", "h");
+		static public Card KingOfHearts = new Card("K", "h");
+		static public Card QueenOfHearts = new Card("Q", "h");
+		static public Card JackOfHearts = new Card("J", "h");
+		static public Card TenOfHearts = new Card("T", "h");
+		static public Card NineOfHearts = new Card("9", "h");
+		static public Card EightOfHearts = new Card("8", "h");
+		static public Card SevenOfHearts = new Card("7", "h");
+		static public Card SixOfHearts = new Card("6", "h");
+		static public Card FiveOfHearts = new Card("5", "h");
+		static public Card FourOfHearts = new Card("4", "h");
+		static public Card ThreeOfHearts = new Card("3", "h");
+		static public Card TwoOfHearts = new Card("2", "h");
+
+		static public Card AceOfDiamonds = new Card("A", "d");
+		static public Card KingOfDiamonds = new Card("K", "d");
+		static public Card QueenOfDiamonds = new Card("Q", "d");
+		static public Card JackOfDiamonds = new Card("J", "d");
+		static public Card TenOfDiamonds = new Card("T", "d");
+		static public Card NineOfDiamonds = new Card("9", "d");
+		static public Card EightOfDiamonds = new Card("8", "d");
+		static public Card SevenOfDiamonds = new Card("7", "d");
+		static public Card SixOfDiamonds = new Card("6", "d");
+		static public Card FiveOfDiamonds = new Card("5", "d");
+		static public Card FourOfDiamonds = new Card("4", "d");
+		static public Card ThreeOfDiamonds = new Card("3", "d");
+		static public Card TwoOfDiamonds = new Card("2", "d");
+
+		static public Card AceOfClubs = new Card("A", "c");
+		static public Card KingOfClubs = new Card("K", "c");
+		static public Card QueenOfClubs = new Card("Q", "c");
+		static public Card JackOfClubs = new Card("J", "c");
+		static public Card TenOfClubs = new Card("T", "c");
+		static public Card NineOfClubs = new Card("9", "c");
+		static public Card EightOfClubs = new Card("8", "c");
+		static public Card SevenOfClubs = new Card("7", "c");
+		static public Card SixOfClubs = new Card("6", "c");
+		static public Card FiveOfClubs = new Card("5", "c");
+		static public Card FourOfClubs = new Card("4", "c");
+		static public Card ThreeOfClubs = new Card("3", "c");
+		static public Card TwoOfClubs = new Card("2", "c");
+
+		static public Card[] Shuffle(Card[] Cards)
+		{
+			Random rng = new Random();
+			for (int i = 0; i < Cards.Length; i++)
+			{
+				int rand = rng.Next(Cards.Length - i);
+				Card temp = Cards[i];
+				Cards[i] = Cards[i + rand];
+				Cards[i + rand] = temp;
+			}
+
+			return Cards;
+		}
+	}
+
+	public class UT_PokerGame : IClassFixture<GamingFixture>
+	{
+		private readonly ITestOutputHelper Output;
+
+		public UT_PokerGame(ITestOutputHelper cout)
+		{
+			Output = cout;
+		}
+
+		[Fact]
+		public void EvaluateSevenCardHand_5CardFlush()
+		{
+			// ASSEMBLE
+			List<Card> actCards = new List<Card>
+			{
+				GamingFixture.EightOfClubs,
+				GamingFixture.FiveOfClubs,
+				GamingFixture.FourOfClubs,
+				GamingFixture.NineOfClubs,
+				GamingFixture.SevenOfHearts,
+				GamingFixture.ThreeOfDiamonds,
+				GamingFixture.TwoOfClubs
+			};
+
+			// ACT
+			int handStrength = PokerGame.GetBest_5From7_All21(actCards);
+			Output.WriteLine($"Calculated strength: {handStrength:X8}");
+
+			// ASSERT
+			Assert.Equal(0x00598542, handStrength);
+		}
+
+		[Fact]
+		public void EvaluateSevenCardHand_6CardFlush()
+		{
+			// ASSEMBLE
+			List<Card> actCards = new List<Card>
+			{
+				GamingFixture.EightOfDiamonds,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.FourOfDiamonds,
+				GamingFixture.NineOfDiamonds,
+				GamingFixture.SevenOfHearts,
+				GamingFixture.ThreeOfDiamonds,
+				GamingFixture.TwoOfDiamonds
+			};
+
+			// ACT
+			int handStrength = PokerGame.GetBest_5From7_All21(actCards);
+			Output.WriteLine($"Calculated strength: {handStrength:X8}");
+
+			// ASSERT
+			Assert.Equal(0x00598543, handStrength);
+		}
+
+		[Fact]
+		public void EvaluateSevenCardHand_7CardFlush()
+		{
+			// ASSEMBLE
+			List<Card> actCards = new List<Card>
+			{
+				GamingFixture.AceOfHearts,
+				GamingFixture.EightOfHearts,
+				GamingFixture.FourOfHearts,
+				GamingFixture.JackOfHearts,
+				GamingFixture.NineOfHearts,
+				GamingFixture.ThreeOfHearts,
+				GamingFixture.TwoOfHearts
+			};
+
+			// ACT
+			int handStrength = PokerGame.GetBest_5From7_All21(actCards);
+			Output.WriteLine($"Calculated strength: {handStrength:X8}");
+
+			// ASSERT
+			Assert.Equal(0x005EB984, handStrength);
+		}
+
+		[Fact]
+		public void EvaluateSevenCardHand_5CardStraight()
+		{
+			// ASSEMBLE
+			List<Card> actCards = new List<Card>
+			{
+				GamingFixture.AceOfDiamonds,
+				GamingFixture.EightOfDiamonds,
+				GamingFixture.JackOfClubs,
+				GamingFixture.NineOfSpades,
+				GamingFixture.QueenOfHearts,
+				GamingFixture.TenOfSpades,
+				GamingFixture.TwoOfClubs
+			};
+
+			// ACT
+			int handStrength = PokerGame.GetBest_5From7_All21(actCards);
+			Output.WriteLine($"Calculated strength: {handStrength:X8}");
+
+			// ASSERT
+			Assert.Equal(0x004CBA98, handStrength);
+		}
+
+		[Fact]
+		public void EvaluateSevenCardHand_5CardStraight_NotContiguous()
+		{
+			// ASSEMBLE
+			List<Card> actCards = new List<Card>
+			{
+				GamingFixture.SixOfDiamonds,
+				GamingFixture.SixOfHearts,
+				GamingFixture.FiveOfClubs,
+				GamingFixture.FiveOfSpades,
+				GamingFixture.FourOfHearts,
+				GamingFixture.ThreeOfSpades,
+				GamingFixture.TwoOfClubs
+			};
+
+			// ACT
+			int handStrength = PokerGame.GetBest_5From7_All21(actCards);
+			Output.WriteLine($"Calculated strength: {handStrength:X8}");
+
+			// ASSERT
+			Assert.Equal(0x00465432, handStrength);
+		}
+
+		[Fact]
+		public void EvaluateSevenCardHand_5CardStraight_TheWheel()
+		{
+			// ASSEMBLE
+			List<Card> actCards = new List<Card>
+			{
+				GamingFixture.SevenOfDiamonds,
+				GamingFixture.AceOfDiamonds,
+				GamingFixture.FiveOfClubs,
+				GamingFixture.FiveOfSpades,
+				GamingFixture.FourOfHearts,
+				GamingFixture.ThreeOfSpades,
+				GamingFixture.TwoOfClubs
+			};
+
+			// ACT
+			int handStrength = PokerGame.GetBest_5From7_All21(actCards);
+			Output.WriteLine($"Calculated strength: {handStrength:X8}");
+
+			// ASSERT
+			Assert.Equal(0x00454321, handStrength);
+		}
+
+		[Fact]
+		public void EvaluateSevenCardHand_6CardStraight_NotTheWheel()
+		{
+			// ASSEMBLE
+			List<Card> actCards = new List<Card>
+			{
+				GamingFixture.SixOfDiamonds,
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.FiveOfClubs,
+				GamingFixture.AceOfSpades,
+				GamingFixture.FourOfHearts,
+				GamingFixture.ThreeOfSpades,
+				GamingFixture.TwoOfClubs
+			};
+
+			// ACT
+			int handStrength = PokerGame.GetBest_5From7_All21(actCards);
+			Output.WriteLine($"Calculated strength: {handStrength:X8}");
+
+			// ASSERT
+			Assert.Equal(0x00465432, handStrength);
+		}
+
+		[Fact]
+		public void EvaluateSevenCardHand_StraightFlush()
+		{
+			// ASSEMBLE
+			List<Card> actCards = new List<Card>
+			{
+				GamingFixture.SixOfDiamonds,
+				GamingFixture.SevenOfDiamonds,
+				GamingFixture.EightOfDiamonds,
+				GamingFixture.NineOfDiamonds,
+				GamingFixture.TenOfDiamonds,
+				GamingFixture.KingOfSpades,
+				GamingFixture.FourOfClubs,
+			};
+
+			// ACT
+			//int handStrength = PokerGame.EvaluateSevenCardHand(actCards);
+			int handStrength = PokerGame.GetBest_5From7_All21(actCards);
+			Output.WriteLine($"Calculated strength: {handStrength:X8}");
+
+			// ASSERT
+			Assert.Equal(0x008A9876, handStrength);
+		}
+
+		[Fact]
+		public void EvaluateSevenCardHand_StraightFlush_TheWheel()
+		{
+			// ASSEMBLE
+			List<Card> actCards = new List<Card>
+			{
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.ThreeOfDiamonds,
+				GamingFixture.FourOfDiamonds,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.AceOfDiamonds,
+				GamingFixture.KingOfSpades,
+				GamingFixture.FourOfClubs,
+			};
+
+			// ACT
+			int handStrength = PokerGame.GetBest_5From7_All21(actCards);
+			Output.WriteLine($"Calculated strength: {handStrength:X8}");
+
+			// ASSERT
+			Assert.Equal(0x00854321, handStrength);
+		}
+
+		[Fact]
+		public void EvaluateSevenCardHand_StraightFlush_TheWheelPlus()
+		{
+			// ASSEMBLE
+			List<Card> actCards = new List<Card>
+			{
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.ThreeOfDiamonds,
+				GamingFixture.FourOfDiamonds,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.AceOfDiamonds,
+				GamingFixture.KingOfSpades,
+				GamingFixture.SixOfDiamonds,
+			};
+
+			// ACT
+			int handStrength = PokerGame.GetBest_5From7_All21(actCards);
+			Output.WriteLine($"Calculated strength: {handStrength:X8}");
+
+			// ASSERT
+			Assert.Equal(0x00865432, handStrength);
+		}
+
+		[Fact]
+		public void EvaluateSevenCardHand_StraightFlush_Broadway()
+		{
+			// ASSEMBLE
+			List<Card> actCards = new List<Card>
+			{
+				GamingFixture.TenOfHearts,
+				GamingFixture.JackOfHearts,
+				GamingFixture.QueenOfHearts,
+				GamingFixture.KingOfHearts,
+				GamingFixture.AceOfHearts,
+				GamingFixture.KingOfSpades,
+				GamingFixture.FourOfClubs,
+			};
+
+			// ACT
+			int handStrength = PokerGame.GetBest_5From7_All21(actCards);
+			Output.WriteLine($"Calculated strength: {handStrength:X8}");
+
+			// ASSERT
+			Assert.Equal(0x008EDCBA, handStrength);
+		}
+
+		[Fact]
+		public void EvaluateSevenCardHand_StraightFlush_BroadwayPlus()
+		{
+			// ASSEMBLE
+			List<Card> actCards = new List<Card>
+			{
+				GamingFixture.TenOfHearts,
+				GamingFixture.JackOfHearts,
+				GamingFixture.QueenOfHearts,
+				GamingFixture.KingOfHearts,
+				GamingFixture.AceOfHearts,
+				GamingFixture.KingOfSpades,
+				GamingFixture.NineOfHearts,
+			};
+
+			// ACT
+			int handStrength = PokerGame.GetBest_5From7_All21(actCards);
+			Output.WriteLine($"Calculated strength: {handStrength:X8}");
+
+			// ASSERT
+			Assert.Equal(0x008EDCBA, handStrength);
+		}
+
+		[Fact]
+		public void EvaluateSevenCardHand_FourOfAKind()
+		{
+			// ASSEMBLE
+			List<Card> actCards = new List<Card>
+			{
+				GamingFixture.TenOfHearts,
+				GamingFixture.JackOfHearts,
+				GamingFixture.JackOfClubs,
+				GamingFixture.KingOfHearts,
+				GamingFixture.JackOfDiamonds,
+				GamingFixture.KingOfSpades,
+				GamingFixture.JackOfSpades,
+			};
+
+			// ACT
+			int handStrength = PokerGame.GetBest_5From7_All21(actCards);
+			Output.WriteLine($"Calculated strength: {handStrength:X8}");
+
+			// ASSERT
+			Assert.Equal(0x007BBBBD, handStrength);
+		}
+
+		[Fact]
+		public void EvaluateSevenCardHand_FullHouse()
+		{
+			// ASSEMBLE
+			List<Card> actCards = new List<Card>
+			{
+				GamingFixture.TenOfHearts,
+				GamingFixture.JackOfHearts,
+				GamingFixture.JackOfClubs,
+				GamingFixture.KingOfHearts,
+				GamingFixture.SixOfDiamonds,
+				GamingFixture.KingOfSpades,
+				GamingFixture.JackOfSpades,
+			};
+
+			// ACT
+			int handStrength = PokerGame.GetBest_5From7_All21(actCards);
+			Output.WriteLine($"Calculated strength: {handStrength:X8}");
+
+			// ASSERT
+			Assert.Equal(0x006BBBDD, handStrength);
+		}
+
+		[Fact]
+		public void EvaluateSevenCardHand_ThreeOfAKind()
+		{
+			// ASSEMBLE
+			List<Card> actCards = new List<Card>
+			{
+				GamingFixture.TenOfHearts,
+				GamingFixture.FiveOfHearts,
+				GamingFixture.KingOfClubs,
+				GamingFixture.KingOfHearts,
+				GamingFixture.SixOfHearts,
+				GamingFixture.KingOfSpades,
+				GamingFixture.JackOfDiamonds,
+			};
+
+			// ACT
+			int handStrength = PokerGame.GetBest_5From7_All21(actCards);
+			Output.WriteLine($"Calculated strength: {handStrength:X8}");
+
+			// ASSERT
+			Assert.Equal(0x003DDDBA, handStrength);
+		}
+
+		[Fact]
+		public void EvaluateSevenCardHand_ThreePair()
+		{
+			// ASSEMBLE
+			List<Card> actCards = new List<Card>
+			{
+				GamingFixture.SixOfHearts,
+				GamingFixture.JackOfHearts,
+				GamingFixture.JackOfClubs,
+				GamingFixture.KingOfHearts,
+				GamingFixture.SixOfDiamonds,
+				GamingFixture.KingOfSpades,
+				GamingFixture.AceOfSpades,
+			};
+
+			// ACT
+			int handStrength = PokerGame.GetBest_5From7_All21(actCards);
+			Output.WriteLine($"Calculated strength: {handStrength:X8}");
+
+			// ASSERT
+			Assert.Equal(0x002DDBBE, handStrength);
+		}
+
+		[Fact]
+		public void EvaluateSevenCardHand_TwoPair()
+		{
+			// ASSEMBLE
+			List<Card> actCards = new List<Card>
+			{
+				GamingFixture.TenOfHearts,
+				GamingFixture.JackOfHearts,
+				GamingFixture.JackOfClubs,
+				GamingFixture.KingOfHearts,
+				GamingFixture.SixOfDiamonds,
+				GamingFixture.KingOfSpades,
+				GamingFixture.AceOfSpades,
+			};
+
+			// ACT
+			int handStrength = PokerGame.GetBest_5From7_All21(actCards);
+			Output.WriteLine($"Calculated strength: {handStrength:X8}");
+
+			// ASSERT
+			Assert.Equal(0x002DDBBE, handStrength);
+		}
+
+		[Fact]
+		public void EvaluateSevenCardHand_OnePair()
+		{
+			// ASSEMBLE
+			List<Card> actCards = new List<Card>
+			{
+				GamingFixture.TenOfHearts,
+				GamingFixture.ThreeOfHearts,
+				GamingFixture.FourOfClubs,
+				GamingFixture.NineOfHearts,
+				GamingFixture.SixOfDiamonds,
+				GamingFixture.ThreeOfSpades,
+				GamingFixture.AceOfSpades,
+			};
+
+			// ACT
+			int handStrength = PokerGame.GetBest_5From7_All21(actCards);
+			Output.WriteLine($"Calculated strength: {handStrength:X8}");
+
+			// ASSERT
+			Assert.Equal(0x00133EA9, handStrength);
+		}
+
+		[Fact]
+		public void EvaluateSevenCardHand_HighCardAce()
+		{
+			// ASSEMBLE
+			List<Card> actCards = new List<Card>
+			{
+				GamingFixture.TenOfHearts,
+				GamingFixture.ThreeOfHearts,
+				GamingFixture.FourOfClubs,
+				GamingFixture.AceOfSpades,
+				GamingFixture.NineOfHearts,
+				GamingFixture.SixOfDiamonds,
+				GamingFixture.SevenOfSpades,
+			};
+
+			// ACT
+			int handStrength = PokerGame.GetBest_5From7_All21(actCards);
+			Output.WriteLine($"Calculated strength: {handStrength:X8}");
+
+			// ASSERT
+			Assert.Equal(0x000EA976, handStrength);
+		}
+
+		[Fact]
+		public void EvaluateSevenCardHand_HighCardNine()
+		{
+			// ASSEMBLE
+			List<Card> actCards = new List<Card>
+			{
+				GamingFixture.TwoOfHearts,
+				GamingFixture.ThreeOfHearts,
+				GamingFixture.FourOfClubs,
+				GamingFixture.FiveOfSpades,
+				GamingFixture.NineOfHearts,
+				GamingFixture.EightOfDiamonds,
+				GamingFixture.SevenOfSpades,
+			};
+
+			// ACT
+			int handStrength = PokerGame.GetBest_5From7_All21(actCards);
+			Output.WriteLine($"Calculated strength: {handStrength:X8}");
+
+			// ASSERT
+			Assert.Equal(0x00098754, handStrength);
+		}
+
+		[Fact]
+		public void GetNumDistinctRanks()
+		{
+			List<Card> cards = new List<Card>();
+
+			cards.Add(GamingFixture.AceOfClubs);
+			Assert.Equal(1, PokerGame.GetNumDistinctRanks(cards));
+
+			cards.Add(GamingFixture.AceOfDiamonds);
+			Assert.Equal(1, PokerGame.GetNumDistinctRanks(cards));
+
+			cards.Add(GamingFixture.KingOfDiamonds);
+			Assert.Equal(2, PokerGame.GetNumDistinctRanks(cards));
+
+			// Method doesn't enforce unique cards in the list.
+			cards.Add(GamingFixture.KingOfDiamonds);
+			cards.Add(GamingFixture.KingOfDiamonds);
+			cards.Add(GamingFixture.KingOfDiamonds);
+			cards.Add(GamingFixture.KingOfDiamonds);
+			cards.Add(GamingFixture.KingOfDiamonds);
+			cards.Add(GamingFixture.KingOfDiamonds);
+			Assert.Equal(2, PokerGame.GetNumDistinctRanks(cards));
+
+			cards.Add(GamingFixture.QueenOfDiamonds);
+			Assert.Equal(3, PokerGame.GetNumDistinctRanks(cards));
+
+			cards.Add(GamingFixture.TwoOfDiamonds);
+			cards.Add(GamingFixture.ThreeOfDiamonds);
+			cards.Add(GamingFixture.FourOfDiamonds);
+			cards.Add(GamingFixture.FiveOfDiamonds);
+			cards.Add(GamingFixture.SixOfDiamonds);
+			cards.Add(GamingFixture.SevenOfDiamonds);
+			cards.Add(GamingFixture.EightOfDiamonds);
+			Assert.Equal(10, PokerGame.GetNumDistinctRanks(cards));
+
+			cards.Add(GamingFixture.TwoOfDiamonds);
+			cards.Add(GamingFixture.ThreeOfDiamonds);
+			cards.Add(GamingFixture.NineOfDiamonds);
+			cards.Add(GamingFixture.FiveOfDiamonds);
+			cards.Add(GamingFixture.TenOfDiamonds);
+			cards.Add(GamingFixture.SevenOfDiamonds);
+			cards.Add(GamingFixture.JackOfDiamonds);
+			Assert.Equal(13, PokerGame.GetNumDistinctRanks(cards));
+		}
+
+		[Fact]
+		public void IsStraight_Basic()
+		{
+			Assert.False(PokerGame.IsStraight(null));
+
+			List<Card> hand = new List<Card>();
+
+			Assert.False(PokerGame.IsStraight(hand));
+
+			hand.Add(GamingFixture.SixOfDiamonds);
+			// We are responsible for sorting from high to low.
+			hand.Sort();
+			hand.Reverse();
+			Assert.True(PokerGame.IsStraight(hand));
+
+			hand.Add(GamingFixture.FiveOfDiamonds);
+			// We are responsible for sorting from high to low.
+			hand.Sort();
+			hand.Reverse();
+			Assert.True(PokerGame.IsStraight(hand));
+
+			hand.Add(GamingFixture.SevenOfDiamonds);
+			// We are responsible for sorting from high to low.
+			hand.Sort();
+			hand.Reverse();
+			Assert.True(PokerGame.IsStraight(hand));
+
+			hand.Add(GamingFixture.TwoOfDiamonds);
+			// We are responsible for sorting from high to low.
+			hand.Sort();
+			hand.Reverse();
+			Assert.False(PokerGame.IsStraight(hand));
+
+			hand.Add(GamingFixture.ThreeOfDiamonds);
+			// We are responsible for sorting from high to low.
+			hand.Sort();
+			hand.Reverse();
+			Assert.False(PokerGame.IsStraight(hand));
+
+			hand.Add(GamingFixture.AceOfDiamonds);
+			// We are responsible for sorting from high to low.
+			hand.Sort();
+			hand.Reverse();
+			Assert.False(PokerGame.IsStraight(hand));
+
+			// This completes The Wheel.
+			hand.Add(GamingFixture.FourOfDiamonds);
+			// We are responsible for sorting from high to low.
+			hand.Sort();
+			hand.Reverse();
+			Assert.True(PokerGame.IsStraight(hand)); // The Wheel
+		}
+
+		[Fact]
+		public void GetCombos()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.AceOfClubs,
+				GamingFixture.EightOfClubs,
+				GamingFixture.FiveOfClubs,
+				GamingFixture.FourOfClubs,
+				GamingFixture.JackOfClubs,
+				GamingFixture.KingOfClubs,
+				GamingFixture.NineOfClubs,
+			};
+
+			List<List<Card>> allCombos = PokerGame.GetCombos(hand, 5);
+			Output.WriteLine($"Here are the {allCombos.Count} combinations:");
+			foreach (List<Card> combo in allCombos)
+			{
+				string output = "Cards: ";
+				foreach (Card card in combo)
+					output += $"{card.Rank}{card.Suit} ";
+				Output.WriteLine($"{output}");
+			}
+		}
+
+		#region Base: 7 Suited Cards
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_7SuitedCards_StrFl7()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.EightOfClubs,
+				GamingFixture.FiveOfClubs,
+				GamingFixture.FourOfClubs,
+				GamingFixture.NineOfClubs,
+				GamingFixture.SevenOfClubs,
+				GamingFixture.SixOfClubs,
+				GamingFixture.TenOfClubs,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("StraightFlush7");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_7SuitedCards_StrFl7_TheWheel()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.AceOfClubs,
+				GamingFixture.FiveOfClubs,
+				GamingFixture.FourOfClubs,
+				GamingFixture.TwoOfClubs,
+				GamingFixture.SevenOfClubs,
+				GamingFixture.SixOfClubs,
+				GamingFixture.ThreeOfClubs,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("StraightFlush7");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+		
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_7SuitedCards_Fl7()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.EightOfClubs,
+				GamingFixture.FiveOfClubs,
+				GamingFixture.FourOfClubs,
+				GamingFixture.NineOfClubs,
+				GamingFixture.TwoOfClubs,
+				GamingFixture.SixOfClubs,
+				GamingFixture.TenOfClubs,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Flush7");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_7SuitedCards_StrFl6()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.AceOfClubs,
+				GamingFixture.EightOfClubs,
+				GamingFixture.FiveOfClubs,
+				GamingFixture.FourOfClubs,
+				GamingFixture.NineOfClubs,
+				GamingFixture.SevenOfClubs,
+				GamingFixture.SixOfClubs,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Flush7");
+			expResults.Add("StraightFlush6");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_7SuitedCards_StrFl6_TheWheel()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.AceOfClubs,
+				GamingFixture.TwoOfClubs,
+				GamingFixture.FiveOfClubs,
+				GamingFixture.FourOfClubs,
+				GamingFixture.ThreeOfClubs,
+				GamingFixture.EightOfClubs,
+				GamingFixture.SixOfClubs,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Flush7");
+			expResults.Add("StraightFlush6");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_7SuitedCards_StrFl5()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.AceOfClubs,
+				GamingFixture.EightOfClubs,
+				GamingFixture.FiveOfClubs,
+				GamingFixture.KingOfClubs,
+				GamingFixture.NineOfClubs,
+				GamingFixture.SevenOfClubs,
+				GamingFixture.SixOfClubs,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Flush7");
+			expResults.Add("StraightFlush5");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_7SuitedCards_StrFl5_TheWheel()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.QueenOfClubs,
+				GamingFixture.FiveOfClubs,
+				GamingFixture.FourOfClubs,
+				GamingFixture.AceOfClubs,
+				GamingFixture.KingOfClubs,
+				GamingFixture.ThreeOfClubs,
+				GamingFixture.TwoOfClubs,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Flush7");
+			expResults.Add("StraightFlush5");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+		#endregion
+
+		#region Base: 6 Suited Cards
+		//
+		// 7-card constraint: Straight7
+		// Can include the following additional hands:
+		// - StraightFlush6
+		// - StraightFlush5
+		// - Flush6 (implied by the Base scenario)
+		// Cannot include StraightFlush5Pair because all ranks must be unique to make Straight7.
+		//
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_6SuitedCards_Str7_StrFl6()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.SixOfDiamonds,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.FourOfDiamonds,
+				GamingFixture.ThreeOfDiamonds,
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.SevenOfDiamonds,
+				GamingFixture.EightOfHearts,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Straight7");
+			expResults.Add("StraightFlush6");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_6SuitedCards_Str7_TheWheel_StrFl6()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.SixOfDiamonds,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.FourOfDiamonds,
+				GamingFixture.ThreeOfDiamonds,
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.SevenOfDiamonds,
+				GamingFixture.AceOfHearts,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Straight7");
+			expResults.Add("StraightFlush6");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_6SuitedCards_Str7_StrFl6_TheWheel()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.SixOfDiamonds,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.FourOfDiamonds,
+				GamingFixture.ThreeOfDiamonds,
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.AceOfDiamonds,
+				GamingFixture.SevenOfHearts,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Straight7");
+			expResults.Add("StraightFlush6");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_6SuitedCards_Str7_StrFl5()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.ThreeOfHearts,
+				GamingFixture.FourOfDiamonds,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.SixOfDiamonds,
+				GamingFixture.SevenOfDiamonds,
+				GamingFixture.EightOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Straight7");
+			expResults.Add("Flush6");
+			expResults.Add("StraightFlush5");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		// public void FindFlushesAndStraights_6SuitedCards_Str7_TheWheel_StrFl5()
+		//
+		// This case is not possible. For the StrFl to not be The Wheel, the Ace
+		// must be the non-suited card. But this means that the 2 - 7 must be suited,
+		// which is a 6-card StrFl instead of a 5-card StrFl.
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_6SuitedCards_Str7_StrFl5_TheWheel()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.AceOfDiamonds,
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.ThreeOfDiamonds,
+				GamingFixture.FourOfDiamonds,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.SixOfHearts,
+				GamingFixture.SevenOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Straight7");
+			expResults.Add("Flush6");
+			expResults.Add("StraightFlush5");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_6SuitedCards_Str7()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.SixOfHearts,
+				GamingFixture.FiveOfClubs,
+				GamingFixture.FourOfHearts,
+				GamingFixture.ThreeOfHearts,
+				GamingFixture.TwoOfHearts,
+				GamingFixture.SevenOfHearts,
+				GamingFixture.EightOfHearts,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Straight7");
+			expResults.Add("Flush6");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_6SuitedCards_Str7_TheWheel()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.SixOfDiamonds,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.FourOfClubs,
+				GamingFixture.ThreeOfDiamonds,
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.SevenOfDiamonds,
+				GamingFixture.AceOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Straight7");
+			expResults.Add("Flush6");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		//
+		// 6-card constraint: Straight6
+		// Can include the following additional hands:
+		// - StraightFlush6
+		// - StraightFlush5Pair (breaking the StraightFlush6 e.g. [234567]7)
+		// - Flush6 (implied by the Base scenario)
+		// Cannot include StraightFlush5Pair because all ranks must be unique to make Straight7.
+		//
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_6SuitedCards_Str6_StrFl6()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.SixOfDiamonds,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.FourOfDiamonds,
+				GamingFixture.ThreeOfDiamonds,
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.SevenOfDiamonds,
+				GamingFixture.NineOfHearts,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("StraightFlush6");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_6SuitedCards_Str6_StrFl6_TheWheel()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.SixOfDiamonds,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.FourOfDiamonds,
+				GamingFixture.ThreeOfDiamonds,
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.AceOfDiamonds,
+				GamingFixture.EightOfHearts,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("StraightFlush6");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_6SuitedCards_StrFl6_StrFl5Pair()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.SevenOfDiamonds,
+				GamingFixture.SixOfDiamonds,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.FourOfDiamonds,
+				GamingFixture.ThreeOfDiamonds,
+				GamingFixture.TwoOfSpades,
+				GamingFixture.TwoOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("StraightFlush6");
+			expResults.Add("StraightFlush5Pair");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_6SuitedCards_StrFl6_TheWheelLow_StrFl5Pair()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.SixOfDiamonds,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.FourOfDiamonds,
+				GamingFixture.ThreeOfDiamonds,
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.AceOfDiamonds,
+				GamingFixture.AceOfSpades,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("StraightFlush6");
+			expResults.Add("StraightFlush5Pair");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_6SuitedCards_StrFl6_TheWheelHigh_StrFl5Pair()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.SixOfDiamonds,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.FourOfDiamonds,
+				GamingFixture.ThreeOfDiamonds,
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.AceOfDiamonds,
+				GamingFixture.SixOfSpades,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("StraightFlush6");
+			expResults.Add("StraightFlush5Pair");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_6SuitedCards_StrFl6_StrFl5Pair_TheWheel()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.SixOfHearts,
+				GamingFixture.SixOfDiamonds,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.FourOfDiamonds,
+				GamingFixture.ThreeOfDiamonds,
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.AceOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("StraightFlush6");
+			expResults.Add("StraightFlush5Pair");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_6SuitedCards_Str6()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.SevenOfDiamonds,
+				GamingFixture.SixOfDiamonds,
+				GamingFixture.FiveOfClubs,
+				GamingFixture.FourOfDiamonds,
+				GamingFixture.ThreeOfDiamonds,
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.NineOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Straight6");
+			expResults.Add("Flush6");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_6SuitedCards_Str6_TheWheel()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.EightOfDiamonds,
+				GamingFixture.SixOfDiamonds,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.FourOfClubs,
+				GamingFixture.ThreeOfDiamonds,
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.AceOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Straight6");
+			expResults.Add("Flush6");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+
+		//
+		// Base Case: 6 suited cards
+		// 5-card constraint: Straight5
+		// Include the following hands:
+		// - StraightFlush5Pair
+		// - StraightFlush5
+		// - Flush6(implied by the Base Case)
+		// - Straight5 (implied by the Constraint)
+		// Cannot include the following hands:
+		// - Straight5Pair, because the non-suited card must be used in the Str5 to prevent it
+		//   from being a StrFl5 (which is a different permutation); the remaining two cards are
+		//   thus the same suit, which means they can't possibly form a pair.
+		//
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_6SuitedCards_StrFl5Pair() // scenario 1
+		{
+			// The Pair does not break a StrFl6.
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.EightOfDiamonds,
+				GamingFixture.NineOfDiamonds,
+				GamingFixture.TenOfDiamonds,
+				GamingFixture.JackOfDiamonds,
+				GamingFixture.QueenOfDiamonds,
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.TwoOfHearts,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Flush6");
+			expResults.Add("StraightFlush5Pair");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_6SuitedCards_StrFl5Pair_TheWheel() // scenario 2
+		{
+			// The Pair does not break a StrFl6.
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.ThreeOfDiamonds,
+				GamingFixture.FourOfDiamonds,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.AceOfDiamonds,
+				GamingFixture.TenOfDiamonds,
+				GamingFixture.TenOfHearts,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Flush6");
+			expResults.Add("StraightFlush5Pair");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_6SuitedCards_StrFl5Pair_LowEnd() // scenario 3
+		{
+			// The Pair does not break a StrFl6.
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.EightOfDiamonds,
+				GamingFixture.NineOfDiamonds,
+				GamingFixture.TenOfDiamonds,
+				GamingFixture.JackOfDiamonds,
+				GamingFixture.QueenOfDiamonds,
+				GamingFixture.AceOfDiamonds,
+				GamingFixture.AceOfHearts,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Flush6");
+			expResults.Add("StraightFlush5Pair");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_6SuitedCards_StrFl5() // scenario 4
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.EightOfDiamonds,
+				GamingFixture.NineOfDiamonds,
+				GamingFixture.TenOfDiamonds,
+				GamingFixture.JackOfDiamonds,
+				GamingFixture.QueenOfDiamonds,
+				GamingFixture.AceOfDiamonds,
+				GamingFixture.TwoOfHearts,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Flush6");
+			expResults.Add("StraightFlush5");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_6SuitedCards_StrFl5_TheWheel()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.AceOfDiamonds,
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.ThreeOfDiamonds,
+				GamingFixture.FourOfDiamonds,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.QueenOfDiamonds,
+				GamingFixture.SevenOfHearts,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Flush6");
+			expResults.Add("StraightFlush5");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_6SuitedCards_Str5()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.ThreeOfSpades,
+				GamingFixture.FourOfDiamonds,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.SixOfDiamonds,
+				GamingFixture.QueenOfDiamonds,
+				GamingFixture.EightOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Flush6");
+			expResults.Add("Straight5");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_6SuitedCards_Str5_TheWheel()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.AceOfDiamonds,
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.ThreeOfSpades,
+				GamingFixture.FourOfDiamonds,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.QueenOfDiamonds,
+				GamingFixture.SevenOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Flush6");
+			expResults.Add("Straight5");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+
+
+		//
+		// Base Case: 6 suited cards
+		// Constraint: none
+		// Can include the following additional hands:
+		// - Flush5Pair
+		// - Flush6 (implied by the Base scenario)
+		// Cannot include the following hands:
+		// - Straight 5 or longer, because that would be a constraint.
+		// - StraightFlush 5 or 6, because there are no straights of any kind.
+		// - More than a single Pair, because that would violate the Base Case (6 unique ranks).
+		//
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_6SuitedCards_Fl5Pair()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.SixOfDiamonds,
+				GamingFixture.EightOfDiamonds,
+				GamingFixture.TenOfDiamonds,
+				GamingFixture.TenOfSpades,
+				GamingFixture.QueenOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Flush5Pair");
+			expResults.Add("Flush6");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_6SuitedCards_Fl6()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.ThreeOfSpades,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.SixOfDiamonds,
+				GamingFixture.EightOfDiamonds,
+				GamingFixture.TenOfDiamonds,
+				GamingFixture.QueenOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Flush6");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+		#endregion
+
+		#region Base: 5 suited cards
+		//
+		// Base Case: 5 suited cards
+		// 7-card constraint: Straight7
+		// Can include the following additional hands:
+		// - StraightFlush5
+		// - Flush5 (implied by the Base scenario)
+		// Cannot include StraightFlush5Pair because all ranks must be unique to make Straight7.
+		// Cannot include Flush5Pair because all ranks must be unique to make Straight7.
+		// Cannot include any combination of matches.
+		//
+		[Fact]
+		[Trait("7CardMashup", "5Suited")]
+		public void FindFlushesAndStraights_5SuitedCards_Str7()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.ThreeOfSpades,
+				GamingFixture.FourOfDiamonds,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.SixOfClubs,
+				GamingFixture.SevenOfDiamonds,
+				GamingFixture.EightOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Straight7");
+			expResults.Add("Flush5");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "5Suited")]
+		public void FindFlushesAndStraights_5SuitedCards_Str7_TheWheel()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.ThreeOfSpades,
+				GamingFixture.FourOfDiamonds,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.SixOfClubs,
+				GamingFixture.SevenOfDiamonds,
+				GamingFixture.AceOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Straight7");
+			expResults.Add("Flush5");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "5Suited")]
+		public void FindFlushesAndStraights_5SuitedCards_Str7_StrFl5()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.ThreeOfDiamonds,
+				GamingFixture.FourOfDiamonds,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.SixOfDiamonds,
+				GamingFixture.SevenOfClubs,
+				GamingFixture.EightOfHearts,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Straight7");
+			expResults.Add("StraightFlush5");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "5Suited")]
+		public void FindFlushesAndStraights_5SuitedCards_Str7_TheWheel_StrFl5()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.TwoOfHearts,
+				GamingFixture.ThreeOfDiamonds,
+				GamingFixture.FourOfDiamonds,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.SixOfDiamonds,
+				GamingFixture.SevenOfDiamonds,
+				GamingFixture.AceOfClubs,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Straight7");
+			expResults.Add("StraightFlush5");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		//
+		// Base Case: 5 suited cards
+		// 6-card constraint: Straight6
+		// Can include the following additional hands:
+		// - StraightFlush5Pair
+		// - StraightFlush5
+		// - Flush5Pair
+		// - Flush5 (implied by the Base scenario)
+		//
+		[Fact]
+		[Trait("7CardMashup", "5Suited")]
+		public void FindFlushesAndStraights_5SuitedCards_Str6()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.ThreeOfSpades,
+				GamingFixture.FourOfDiamonds,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.SixOfClubs,
+				GamingFixture.SevenOfDiamonds,
+				GamingFixture.NineOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Straight6");
+			expResults.Add("Flush5");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "5Suited")]
+		public void FindFlushesAndStraights_5SuitedCards_Str6_TheWheel()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.ThreeOfSpades,
+				GamingFixture.FourOfDiamonds,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.SixOfClubs,
+				GamingFixture.EightOfDiamonds,
+				GamingFixture.AceOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Straight6");
+			expResults.Add("Flush5");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "5Suited")]
+		public void FindFlushesAndStraights_5SuitedCards_Str6_StrFl5Pair()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.ThreeOfDiamonds,
+				GamingFixture.FourOfDiamonds,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.SixOfDiamonds,
+				GamingFixture.SevenOfHearts,
+				GamingFixture.SevenOfSpades,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("StraightFlush5Pair");
+			expResults.Add("Straight6");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "5Suited")]
+		public void FindFlushesAndStraights_5SuitedCards_Str6_TheWheel_StrFl5Pair()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.ThreeOfDiamonds,
+				GamingFixture.FourOfDiamonds,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.SixOfDiamonds,
+				GamingFixture.AceOfClubs,
+				GamingFixture.AceOfSpades,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("StraightFlush5Pair");
+			expResults.Add("Straight6");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "5Suited")]
+		public void FindFlushesAndStraights_5SuitedCards_Str6_StrFl5Pair_TheWheel()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.ThreeOfDiamonds,
+				GamingFixture.FourOfDiamonds,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.SixOfSpades,
+				GamingFixture.SixOfClubs,
+				GamingFixture.AceOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("StraightFlush5Pair");
+			expResults.Add("Straight6");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "5Suited")]
+		public void FindFlushesAndStraights_5SuitedCards_Str6_StrFl5()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.ThreeOfDiamonds,
+				GamingFixture.FourOfDiamonds,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.SixOfDiamonds,
+				GamingFixture.SevenOfHearts,
+				GamingFixture.NineOfSpades,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Straight6");
+			expResults.Add("StraightFlush5");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "5Suited")]
+		public void FindFlushesAndStraights_5SuitedCards_Str6_TheWheel_StrFl5()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.ThreeOfDiamonds,
+				GamingFixture.FourOfDiamonds,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.SixOfDiamonds,
+				GamingFixture.AceOfClubs,
+				GamingFixture.KingOfSpades,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Straight6");
+			expResults.Add("StraightFlush5");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "5Suited")]
+		public void FindFlushesAndStraights_5SuitedCards_Str6_StrFl5_TheWheel()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.ThreeOfDiamonds,
+				GamingFixture.FourOfDiamonds,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.SixOfSpades,
+				GamingFixture.EightOfClubs,
+				GamingFixture.AceOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Straight6");
+			expResults.Add("StraightFlush5");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "5Suited")]
+		public void FindFlushesAndStraights_5SuitedCards_Str6_Fl5Pair()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.ThreeOfDiamonds,
+				GamingFixture.FourOfClubs,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.SixOfDiamonds,
+				GamingFixture.SevenOfDiamonds,
+				GamingFixture.FourOfSpades,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Flush5Pair");
+			expResults.Add("Straight6");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "5Suited")]
+		public void FindFlushesAndStraights_5SuitedCards_Str6_TheWheel_Fl5Pair()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.ThreeOfDiamonds,
+				GamingFixture.FourOfHearts,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.SixOfDiamonds,
+				GamingFixture.FourOfClubs,
+				GamingFixture.AceOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Flush5Pair");
+			expResults.Add("Straight6");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		//
+		// Base Case: 5 suited cards
+		// 5-card constraint: Straight5
+		// Include the following hands:
+		// - StraightFlush5Pair
+		// - StraightFlush5
+		// - Flush5Pair
+		// - Straight5Pair
+		// - Flush5(implied by the Base Case)
+		// - Straight5 (implied by the Constraint)
+		// Cannot include the following hands:
+		//
+		[Fact]
+		[Trait("7CardMashup", "5Suited")]
+		public void FindFlushesAndStraights_5SuitedCards_Str5_StrFl5Pair()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.ThreeOfDiamonds,
+				GamingFixture.FourOfDiamonds,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.SixOfDiamonds,
+				GamingFixture.EightOfHearts,
+				GamingFixture.EightOfSpades,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("StraightFlush5Pair");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "5Suited")]
+		public void FindFlushesAndStraights_5SuitedCards_Str5_TheWheel_StrFl5Pair()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.ThreeOfDiamonds,
+				GamingFixture.FourOfDiamonds,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.SevenOfHearts,
+				GamingFixture.SevenOfClubs,
+				GamingFixture.AceOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("StraightFlush5Pair");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "5Suited")]
+		public void FindFlushesAndStraights_5SuitedCards_Str5_StrFl5()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.ThreeOfDiamonds,
+				GamingFixture.FourOfDiamonds,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.SixOfDiamonds,
+				GamingFixture.EightOfHearts,
+				GamingFixture.JackOfSpades,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("StraightFlush5");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "5Suited")]
+		public void FindFlushesAndStraights_5SuitedCards_Str5_TheWheel_StrFl5()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.ThreeOfDiamonds,
+				GamingFixture.FourOfDiamonds,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.SevenOfHearts,
+				GamingFixture.QueenOfClubs,
+				GamingFixture.AceOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("StraightFlush5");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "5Suited")]
+		public void FindFlushesAndStraights_5SuitedCards_Str5_Fl5Pair()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.ThreeOfDiamonds,
+				GamingFixture.FourOfClubs,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.SixOfDiamonds,
+				GamingFixture.FourOfHearts,
+				GamingFixture.EightOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Flush5Pair");
+			expResults.Add("Straight5");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "5Suited")]
+		public void FindFlushesAndStraights_5SuitedCards_Str5_TheWheel_Fl5Pair()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.ThreeOfDiamonds,
+				GamingFixture.FourOfClubs,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.TenOfDiamonds,
+				GamingFixture.FourOfHearts,
+				GamingFixture.AceOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Flush5Pair");
+			expResults.Add("Straight5");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "5Suited")]
+		public void FindFlushesAndStraights_5SuitedCards_Str5Pair_Fl5()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.ThreeOfDiamonds,
+				GamingFixture.FourOfClubs,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.SixOfDiamonds,
+				GamingFixture.EightOfHearts,
+				GamingFixture.EightOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Flush5");
+			expResults.Add("Straight5Pair");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "5Suited")]
+		public void FindFlushesAndStraights_5SuitedCards_Str5Pair_TheWheel_Fl5()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.ThreeOfDiamonds,
+				GamingFixture.FourOfClubs,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.AceOfDiamonds,
+				GamingFixture.EightOfHearts,
+				GamingFixture.EightOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Flush5");
+			expResults.Add("Straight5Pair");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "5Suited")]
+		public void FindFlushesAndStraights_5SuitedCards_Str5_Fl5()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.ThreeOfDiamonds,
+				GamingFixture.FourOfClubs,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.SixOfDiamonds,
+				GamingFixture.EightOfHearts,
+				GamingFixture.TenOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Flush5");
+			expResults.Add("Straight5");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "5Suited")]
+		public void FindFlushesAndStraights_5SuitedCards_Str5_TheWheel_Fl5()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.TwoOfDiamonds,
+				GamingFixture.ThreeOfDiamonds,
+				GamingFixture.FourOfClubs,
+				GamingFixture.FiveOfDiamonds,
+				GamingFixture.AceOfDiamonds,
+				GamingFixture.EightOfHearts,
+				GamingFixture.TenOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Flush5");
+			expResults.Add("Straight5");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+		#endregion // Base: 5 suited cards
+
+		#region Base: 7 Card Run
+		//
+		// Do not include flushes because straight+flush combos are covered by other tests.
+		// Can include the following hands:
+		// - Straight7 (implied by the Base scenario)
+		//
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_7CardRun_Str7()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.AceOfSpades,
+				GamingFixture.EightOfClubs,
+				GamingFixture.NineOfHearts,
+				GamingFixture.JackOfSpades,
+				GamingFixture.KingOfSpades,
+				GamingFixture.QueenOfClubs,
+				GamingFixture.TenOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Straight7");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_7CardRun_Str7_TheWheel()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.AceOfSpades,
+				GamingFixture.TwoOfClubs,
+				GamingFixture.ThreeOfHearts,
+				GamingFixture.FourOfSpades,
+				GamingFixture.FiveOfSpades,
+				GamingFixture.SixOfClubs,
+				GamingFixture.SevenOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Straight7");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+		#endregion
+
+
+		#region Base: 6 Card Run
+		//
+		// Do not include flushes because straight+flush combos are covered by other tests.
+		// Can include the following hands:
+		// - Straight5Pair
+		// - Straight6 (implied by the Base scenario)
+		//
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_6CardRun_Str5Pair()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.AceOfSpades,
+				GamingFixture.AceOfClubs,
+				GamingFixture.NineOfHearts,
+				GamingFixture.JackOfSpades,
+				GamingFixture.KingOfSpades,
+				GamingFixture.QueenOfClubs,
+				GamingFixture.TenOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Straight5Pair");
+			expResults.Add("Straight6");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_6CardRun_Str5Pair_TheWheel()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.AceOfSpades,
+				GamingFixture.TwoOfClubs,
+				GamingFixture.ThreeOfHearts,
+				GamingFixture.FourOfSpades,
+				GamingFixture.FiveOfSpades,
+				GamingFixture.SixOfClubs,
+				GamingFixture.SixOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Straight5Pair");
+			expResults.Add("Straight6");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_6CardRun_Str6()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.AceOfSpades,
+				GamingFixture.TwoOfClubs,
+				GamingFixture.NineOfHearts,
+				GamingFixture.JackOfSpades,
+				GamingFixture.KingOfSpades,
+				GamingFixture.QueenOfClubs,
+				GamingFixture.TenOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Straight6");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_6CardRun_Str6_TheWheel()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.AceOfSpades,
+				GamingFixture.TwoOfClubs,
+				GamingFixture.ThreeOfHearts,
+				GamingFixture.FourOfSpades,
+				GamingFixture.FiveOfSpades,
+				GamingFixture.SixOfClubs,
+				GamingFixture.EightOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Straight6");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+		#endregion
+
+		#region Base: 5 Card Run
+		//
+		// Do not include flushes because straight+flush combos are covered by other tests.
+		// Can include the following hands:
+		// - Straight5Pair
+		// - Straight5 (implied by the Base scenario)
+		//
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_5CardRun_Str5Pair()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.AceOfSpades,
+				GamingFixture.AceOfClubs,
+				GamingFixture.AceOfHearts,
+				GamingFixture.JackOfSpades,
+				GamingFixture.KingOfSpades,
+				GamingFixture.QueenOfClubs,
+				GamingFixture.TenOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Straight5Pair");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_5CardRun_Str5Pair_TheWheel()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.AceOfSpades,
+				GamingFixture.TwoOfClubs,
+				GamingFixture.ThreeOfHearts,
+				GamingFixture.FourOfSpades,
+				GamingFixture.FiveOfSpades,
+				GamingFixture.AceOfClubs,
+				GamingFixture.AceOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Straight5Pair");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_5CardRun_Str5()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.AceOfSpades,
+				GamingFixture.TwoOfClubs,
+				GamingFixture.EightOfHearts,
+				GamingFixture.JackOfSpades,
+				GamingFixture.KingOfSpades,
+				GamingFixture.QueenOfClubs,
+				GamingFixture.TenOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Straight5");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_6CardRun_Str5_TheWheel()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.AceOfSpades,
+				GamingFixture.TwoOfClubs,
+				GamingFixture.ThreeOfHearts,
+				GamingFixture.FourOfSpades,
+				GamingFixture.FiveOfSpades,
+				GamingFixture.SevenOfClubs,
+				GamingFixture.EightOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Straight5");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+		#endregion
+
+		#region Matches
+		//
+		// Do not include flushes or straights because those are covered in other tests.
+		// Can include the following hands:
+		// - QuadSet
+		// - SetPairPair
+		// - QuadPair
+		// - SetSet
+		// - PairPairPair
+		// - SetPair
+		// - Quad
+		// - PairPair
+		// - Set
+		// - Pair
+		//
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_Matches_QuadSet()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.AceOfSpades,
+				GamingFixture.AceOfClubs,
+				GamingFixture.AceOfHearts,
+				GamingFixture.JackOfSpades,
+				GamingFixture.AceOfDiamonds,
+				GamingFixture.JackOfClubs,
+				GamingFixture.JackOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("QuadSet");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_Matches_SetPairPair()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.ThreeOfSpades,
+				GamingFixture.AceOfClubs,
+				GamingFixture.ThreeOfHearts,
+				GamingFixture.JackOfSpades,
+				GamingFixture.AceOfSpades,
+				GamingFixture.JackOfClubs,
+				GamingFixture.JackOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("SetPairPair");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_Matches_QuadPair()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.ThreeOfSpades,
+				GamingFixture.JackOfHearts,
+				GamingFixture.ThreeOfHearts,
+				GamingFixture.JackOfSpades,
+				GamingFixture.AceOfSpades,
+				GamingFixture.JackOfClubs,
+				GamingFixture.JackOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("QuadPair");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_Matches_SetSet()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.ThreeOfSpades,
+				GamingFixture.JackOfHearts,
+				GamingFixture.ThreeOfHearts,
+				GamingFixture.JackOfSpades,
+				GamingFixture.AceOfSpades,
+				GamingFixture.ThreeOfClubs,
+				GamingFixture.JackOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("SetSet");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_Matches_PairPairPair()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.ThreeOfSpades,
+				GamingFixture.JackOfClubs,
+				GamingFixture.ThreeOfHearts,
+				GamingFixture.JackOfSpades,
+				GamingFixture.AceOfSpades,
+				GamingFixture.AceOfClubs,
+				GamingFixture.FiveOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("PairPairPair");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_Matches_SetPair()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.ThreeOfSpades,
+				GamingFixture.JackOfClubs,
+				GamingFixture.ThreeOfHearts,
+				GamingFixture.SixOfSpades,
+				GamingFixture.AceOfSpades,
+				GamingFixture.JackOfHearts,
+				GamingFixture.JackOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("SetPair");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_Matches_Quad()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.ThreeOfSpades,
+				GamingFixture.JackOfHearts,
+				GamingFixture.FourOfHearts,
+				GamingFixture.JackOfSpades,
+				GamingFixture.AceOfSpades,
+				GamingFixture.JackOfClubs,
+				GamingFixture.JackOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Quad");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_Matches_PairPair()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.ThreeOfSpades,
+				GamingFixture.QueenOfClubs,
+				GamingFixture.ThreeOfHearts,
+				GamingFixture.JackOfSpades,
+				GamingFixture.AceOfSpades,
+				GamingFixture.JackOfClubs,
+				GamingFixture.FourOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("PairPair");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_Matches_Set()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.ThreeOfSpades,
+				GamingFixture.FourOfClubs,
+				GamingFixture.TwoOfHearts,
+				GamingFixture.FourOfSpades,
+				GamingFixture.AceOfSpades,
+				GamingFixture.NineOfClubs,
+				GamingFixture.FourOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Set");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_Matches_Pair()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.ThreeOfSpades,
+				GamingFixture.TwoOfClubs,
+				GamingFixture.ThreeOfHearts,
+				GamingFixture.JackOfSpades,
+				GamingFixture.AceOfSpades,
+				GamingFixture.SixOfClubs,
+				GamingFixture.TenOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("Pair");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+		#endregion
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_HighCard_Highest()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.AceOfSpades,
+				GamingFixture.KingOfClubs,
+				GamingFixture.QueenOfHearts,
+				GamingFixture.JackOfSpades,
+				GamingFixture.NineOfSpades,
+				GamingFixture.EightOfClubs,
+				GamingFixture.SevenOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("HighCard");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+
+		[Fact]
+		[Trait("7CardMashup", "POC")]
+		public void FindFlushesAndStraights_HighCard_Lowest()
+		{
+			List<Card> hand = new List<Card>
+			{
+				GamingFixture.TwoOfSpades,
+				GamingFixture.ThreeOfClubs,
+				GamingFixture.FourOfHearts,
+				GamingFixture.FiveOfSpades,
+				GamingFixture.SevenOfSpades,
+				GamingFixture.EightOfClubs,
+				GamingFixture.NineOfDiamonds,
+			};
+			hand.Sort();
+			hand.Reverse();
+
+			List<string> rankings = PokerGame.PocNewMethodFor7Cards(hand);
+			foreach (string r in rankings)
+				Output.WriteLine($"{r}");
+
+			List<string> expResults = new List<string>();
+			expResults.Add("HighCard");
+
+			Assert.Equal(expResults.Count, rankings.Count);
+			foreach (string expRes in expResults)
+				Assert.Contains(expRes, rankings);
+		}
+	}
+}


### PR DESCRIPTION
This code determines the strength of poker hands so that two hands can be
compared. Currently this is used to determine hand probabilities via
simulation, but in the future something resembling a real game could be
made using this code.

Three types of hands are analyzed:
- 5-card poker hand from 5 random cards
- 5-card poker hand from 7 random cards (like stud or hold'em)
- 7-card poker hand from 7 random cards (experiment to see how "weird" hands
  compare to standard poker hands when you must play all 7 cards)

Signed-off-by: Patrick Luhmann <patrick.luhmann@gmail.com>